### PR TITLE
Fix "Namespace package problem" with ckanext folder

### DIFF
--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,0 +1,8 @@
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)
+


### PR DESCRIPTION
This fixes the following error

>  error: Namespace package problem: ckanext is a namespace package, but its
>  **init**.py does not call declare_namespace()! Please fix it.
>  (See the setuptools manual under "Namespace Packages" for details.)
