### PR TITLE
Add option to allow HTML when rendering markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ env:
 install:
     - bash bin/travis-build.bash
 script: sh bin/travis-run.sh
+sudo: required

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ ckanext.pages.organization_menu = False
 By default these are all set to True, like on a default install.
 
 
+To enable HTML output for the pages (along with Markdown), add the following to your config:
+
+```
+ckanext.pages.allow_html = True
+```
+
+By default this option is set to False. Note that this feature is only available for CKAN >= 2.3. For older versions of CKAN, this option has no effect.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ ckanext.pages.allow_html = True
 ```
 
 By default this option is set to False. Note that this feature is only available for CKAN >= 2.3. For older versions of CKAN, this option has no effect.
+Use this option with care and only allow this if you trust the input of your users.

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -48,6 +48,13 @@ def build_pages_nav_main(*args):
 
     return output
 
+def render_content(content):
+    allow_html = p.toolkit.asbool(config.get('ckanext.pages.allow_html', False))
+    try:
+        return h.render_markdown(content, allow_html=allow_html)
+    except TypeError: 
+        # allow_html is only available in CKAN >= 2.3
+        return h.render_markdown(content)
 
 
 class PagesPlugin(p.SingletonPlugin):
@@ -74,7 +81,8 @@ class PagesPlugin(p.SingletonPlugin):
 
     def get_helpers(self):
         return {
-            'build_nav_main': build_pages_nav_main
+            'build_nav_main': build_pages_nav_main,
+            'render_content': render_content,
         }
 
     def after_map(self, map):

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -23,3 +23,36 @@ class TestUpdate(helpers.FunctionalTestBase):
         )
         response = response.follow(extra_environ=env)
         assert '<h1 class="page-heading">Page Title</h1>' in response.body
+
+    @helpers.change_config('ckanext.pages.allow_html', 'True')
+    def test_rendering_with_html_allowed(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        response = self.app.post(
+            url=toolkit.url_for('pages_edit', page='/test_html_page'),
+            params={
+                'title': 'HTML allowed',
+                'name': 'page_html_allowed',
+                'content': '<a href="/test">Test</a>',
+            },
+            extra_environ=env,
+        )
+        response = response.follow(extra_environ=env)
+        if toolkit.check_ckan_version(min_version='2.3'):
+            assert '<h1 class="page-heading">HTML allowed</h1><a href="/test">Test</a>' in response.body
+        else:
+            assert '<h1 class="page-heading">HTML allowed</h1>Test' in response.body
+
+    @helpers.change_config('ckanext.pages.allow_html', 'False')
+    def test_rendering_with_html_disallowed(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        response = self.app.post(
+            url=toolkit.url_for('pages_edit', page='/test_html_page'),
+            params={
+                'title': 'HTML disallowed',
+                'name': 'page_html_disallowed',
+                'content': '<a href="/test">Test</a>',
+            },
+            extra_environ=env,
+        )
+        response = response.follow(extra_environ=env)
+        assert '<h1 class="page-heading">HTML disallowed</h1>Test' in response.body

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -42,24 +42,11 @@ class TestUpdate(helpers.FunctionalTestBase):
             extra_environ=env,
         )
         response = response.follow(extra_environ=env)
+        assert_in('<h1 class="page-heading">Allowed</h1>', response.body)
         if toolkit.check_ckan_version(min_version='2.3'):
-            assert_in(
-                (
-                    '<h1 class="page-heading">Allowed</h1>'
-                    '<div class="ckanext-pages-content">'
-                    '<a href="/test">Test</a>'
-                    '</div>'
-                ),
-                response.body
-            )
+            assert_in('<p><a href="/test">Test</a>', response.body)
         else:
-            assert_in(
-                (
-                    '<h1 class="page-heading">Allowed</h1>'
-                    '<div class="ckanext-pages-content">Test</div>'
-                ),
-                response.body
-            )
+            assert_in('<p>Test', response.body)
 
     @helpers.change_config('ckanext.pages.allow_html', 'False')
     def test_rendering_with_html_disallowed(self):
@@ -74,10 +61,6 @@ class TestUpdate(helpers.FunctionalTestBase):
             extra_environ=env,
         )
         response = response.follow(extra_environ=env)
-        assert_in(
-            (
-                '<h1 class="page-heading">Disallowed</h1>'
-                '<div class="ckanext-pages-content">Test</div>'
-            ),
-            response.body
-        )
+        assert_in('<h1 class="page-heading">Disallowed</h1>', response.body)
+        assert_in('<p>Test', response.body)
+        assert_not_in('<p><a href="/test">Test</a>', response.body)

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -1,5 +1,6 @@
 from ckan.plugins import toolkit
 from ckan.new_tests import factories, helpers
+from nose.tools import assert_in, assert_not_in
 import ckan.model as model
 
 from ckanext.pages import db
@@ -26,7 +27,7 @@ class TestUpdate(helpers.FunctionalTestBase):
             extra_environ=env,
         )
         response = response.follow(extra_environ=env)
-        assert '<h1 class="page-heading">Page Title</h1>' in response.body
+        assert_in('<h1 class="page-heading">Page Title</h1>', response.body)
 
     @helpers.change_config('ckanext.pages.allow_html', 'True')
     def test_rendering_with_html_allowed(self):
@@ -34,7 +35,7 @@ class TestUpdate(helpers.FunctionalTestBase):
         response = self.app.post(
             url=toolkit.url_for('pages_edit', page='/test_html_page'),
             params={
-                'title': 'HTML allowed',
+                'title': 'Allowed',
                 'name': 'page_html_allowed',
                 'content': '<a href="/test">Test</a>',
             },
@@ -42,9 +43,23 @@ class TestUpdate(helpers.FunctionalTestBase):
         )
         response = response.follow(extra_environ=env)
         if toolkit.check_ckan_version(min_version='2.3'):
-            assert '<h1 class="page-heading">HTML allowed</h1><a href="/test">Test</a>' in response.body
+            assert_in(
+                (
+                    '<h1 class="page-heading">Allowed</h1>'
+                    '<div class="ckanext-pages-content">'
+                    '<a href="/test">Test</a>'
+                    '</div>'
+                ),
+                response.body
+            )
         else:
-            assert '<h1 class="page-heading">HTML allowed</h1>Test' in response.body
+            assert_in(
+                (
+                    '<h1 class="page-heading">Allowed</h1>'
+                    '<div class="ckanext-pages-content">Test</div>'
+                ),
+                response.body
+            )
 
     @helpers.change_config('ckanext.pages.allow_html', 'False')
     def test_rendering_with_html_disallowed(self):
@@ -52,11 +67,17 @@ class TestUpdate(helpers.FunctionalTestBase):
         response = self.app.post(
             url=toolkit.url_for('pages_edit', page='/test_html_page'),
             params={
-                'title': 'HTML disallowed',
+                'title': 'Disallowed',
                 'name': 'page_html_disallowed',
                 'content': '<a href="/test">Test</a>',
             },
             extra_environ=env,
         )
         response = response.follow(extra_environ=env)
-        assert '<h1 class="page-heading">HTML disallowed</h1>Test' in response.body
+        assert_in(
+            (
+                '<h1 class="page-heading">Disallowed</h1>'
+                '<div class="ckanext-pages-content">Test</div>'
+            ),
+            response.body
+        )

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -1,10 +1,14 @@
 from ckan.plugins import toolkit
 from ckan.new_tests import factories, helpers
+import ckan.model as model
+
+from ckanext.pages import db
 
 
 class TestUpdate(helpers.FunctionalTestBase):
     def setup(self):
         super(TestUpdate, self).setup()
+        db.init_db(model)
         self.user = factories.Sysadmin()
         self.app = self._get_test_app()
 

--- a/ckanext/pages/theme/templates_main/ckanext_pages/group_page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/group_page.html
@@ -6,7 +6,7 @@
   {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='group_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
   <h1 class="page-heading">{{ c.page.title }}</h1>
   {% if c.page.content %}
-    {{ h.render_markdown(c.page.content) }}
+    {{ h.render_content(c.page.content) }}
   {% else %}
     <p class="empty">{{ _('This page currently has no content') }}</p>
   {% endif %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/organization_page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/organization_page.html
@@ -6,7 +6,7 @@
   {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='org_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
   <h1 class="page-heading">{{ c.page.title }}</h1>
   {% if c.page.content %}
-    {{ h.render_markdown(c.page.content) }}
+    {{ h.render_content(c.page.content) }}
   {% else %}
     <p class="empty">{{ _('This page currently has no content') }}</p>
   {% endif %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page.html
@@ -10,7 +10,7 @@
     <h1 class="page-heading">{{ c.page.title }}</h1>
     {% if c.page.content %}
       <div class="ckanext-pages-content">
-          {{ h.render_markdown(c.page.content) }}
+          {{ h.render_content(c.page.content) }}
       </div>
     {% else %}
       <p class="empty">{{ _('This page currently has no content') }}</p>


### PR DESCRIPTION
In CKAN 2.3 (specifically with [PR #1774](https://github.com/ckan/ckan/pull/1774)) the `render_markdown` method got a new parameter `allow_html` which prevents the filtering of HTML in the content.

I want to enable this feature in ckanext-pages and suggest a new config option to control that:

```
ckanext.pages.allow_html = True
```

By default it is `False`.

To prevent having to call this explicitly in the template (e.g. `h.render_markdown(content, allow_html=True)`), I added a new helper function called `render_content`. That might be useful in the future, if the API of `render_markdown` changes again, or different kind of renderings should be supported.

To keep the plugin independent of the CKAN version, `render_content` tries to call the `render_markdown` with the new `allow_html` named argument, and silently falls back to the version without the parameter, if it fails.