### PR TITLE
added kwarg extend_existing=True to init_db()

### DIFF
--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -110,7 +110,7 @@ def init_db(model):
         sa.Column('created', types.DateTime, default=datetime.datetime.utcnow),
         sa.Column('modified', types.DateTime, default=datetime.datetime.utcnow),
         sa.Column('extras', types.UnicodeText, default=u'{}'),
-	extend_existing=True
+        extend_existing=True
     )
 
     model.meta.mapper(

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -110,6 +110,7 @@ def init_db(model):
         sa.Column('created', types.DateTime, default=datetime.datetime.utcnow),
         sa.Column('modified', types.DateTime, default=datetime.datetime.utcnow),
         sa.Column('extras', types.UnicodeText, default=u'{}'),
+	extend_existing=True
     )
 
     model.meta.mapper(


### PR DESCRIPTION
This should address #27 by adding the (default False) kwarg "extend_existing=True" to the init_db() function of db.py.

Tested on datacats ckan "latest" (2.5a ckan master).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ckan/ckanext-pages/28)
<!-- Reviewable:end -->
