### PR TITLE
fixes a few things. wrong argument, datetime in json, API broken

### DIFF
--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -156,9 +156,9 @@ def _pages_update(context, data_dict):
         out.group_id = org_id
         out.name = page
     items = ['title', 'content', 'name', 'private',
-             'order', 'page_type', 'publish_date', 'content']
+             'order', 'page_type', 'publish_date']
     for item in items:
-        setattr(out, item, data.get(item))
+        setattr(out, item, data.get(item,'page' if item =='page_type' else None)) #backward compatible with older version where page_type does not exist
 
     extras = {}
     extra_keys = set(schema.keys()) - set(items + ['id', 'created'])

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -201,7 +201,7 @@ def pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-@tk.side_effect_free
+
 def pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_update', context, data_dict)
@@ -209,7 +209,7 @@ def pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-@tk.side_effect_free
+
 def pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_delete', context, data_dict)
@@ -233,7 +233,7 @@ def org_pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-@tk.side_effect_free
+
 def org_pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_update', context, data_dict)
@@ -241,7 +241,7 @@ def org_pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-@tk.side_effect_free
+
 def org_pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_delete', context, data_dict)
@@ -265,7 +265,7 @@ def group_pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-@tk.side_effect_free
+
 def group_pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_update', context, data_dict)
@@ -273,7 +273,7 @@ def group_pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-@tk.side_effect_free
+
 def group_pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_delete', context, data_dict)

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -6,7 +6,9 @@ import ckan.lib.navl.dictization_functions as df
 import ckan.new_authz as new_authz
 import ckan.lib.uploader as uploader
 import ckan.lib.helpers as h
+from ckan.plugins import toolkit as tk
 from HTMLParser import HTMLParser
+
 
 import db
 def page_name_validator(key, data, errors, context):
@@ -110,7 +112,7 @@ def _pages_list(context, data_dict):
         pg_row = {'title': pg.title,
                   'content': pg.content,
                   'name': pg.name,
-                  'publish_date': pg.publish_date,
+                  'publish_date': pg.publish_date.isoformat() if pg.publish_date else None,
                   'group_id': pg.group_id,
                   'page_type': pg.page_type,
                  }
@@ -191,6 +193,7 @@ def pages_upload(context, data_dict):
         )
     return {'url': image_url}
 
+@tk.side_effect_free
 def pages_show(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_show', context, data_dict)
@@ -198,7 +201,7 @@ def pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-
+@tk.side_effect_free
 def pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_update', context, data_dict)
@@ -206,7 +209,7 @@ def pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-
+@tk.side_effect_free
 def pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_delete', context, data_dict)
@@ -214,7 +217,7 @@ def pages_delete(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
 
-
+@tk.side_effect_free
 def pages_list(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_pages_list', context, data_dict)
@@ -222,7 +225,7 @@ def pages_list(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_list(context, data_dict)
 
-
+@tk.side_effect_free
 def org_pages_show(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_show', context, data_dict)
@@ -230,7 +233,7 @@ def org_pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-
+@tk.side_effect_free
 def org_pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_update', context, data_dict)
@@ -238,7 +241,7 @@ def org_pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-
+@tk.side_effect_free
 def org_pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_delete', context, data_dict)
@@ -246,7 +249,7 @@ def org_pages_delete(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
 
-
+@tk.side_effect_free
 def org_pages_list(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_org_pages_list', context, data_dict)
@@ -254,7 +257,7 @@ def org_pages_list(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_list(context, data_dict)
 
-
+@tk.side_effect_free
 def group_pages_show(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_show', context, data_dict)
@@ -262,7 +265,7 @@ def group_pages_show(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_show(context, data_dict)
 
-
+@tk.side_effect_free
 def group_pages_update(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_update', context, data_dict)
@@ -270,7 +273,7 @@ def group_pages_update(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
 
-
+@tk.side_effect_free
 def group_pages_delete(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_delete', context, data_dict)
@@ -278,7 +281,7 @@ def group_pages_delete(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
 
-
+@tk.side_effect_free
 def group_pages_list(context, data_dict):
     try:
         p.toolkit.check_access('ckanext_group_pages_list', context, data_dict)

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -266,7 +266,7 @@ class PagesController(p.toolkit.BaseController):
                        'page': page}
         )
         if _page is None:
-            return self._pages_list_pages(p)
+            return self._pages_list_pages(page_type)
         p.toolkit.c.page = _page
         self._inject_views_into_page(_page)
 
@@ -380,5 +380,3 @@ class PagesController(p.toolkit.BaseController):
         return """<script type='text/javascript'>
                       window.parent.CKEDITOR.tools.callFunction(%s, '%s');
                   </script>""" % (p.toolkit.request.GET['CKEditorFuncNum'], url['url'])
-
-

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -5,7 +5,6 @@ ignore_missing = toolkit.get_validator('ignore_missing')
 
 import ckan.plugins as p
 import ckan.lib.helpers as h
-
 import actions
 import auth
 
@@ -165,6 +164,7 @@ class PagesPlugin(p.SingletonPlugin):
                     action='blog_show', ckan_icon='file', controller=controller, highlight_actions='blog_edit blog_index blog_show')
         return map
 
+
     def get_actions(self):
         actions_dict = {
             'ckanext_pages_show': actions.pages_show,
@@ -240,4 +240,3 @@ class TextBoxView(p.SingletonPlugin):
 
     def setup_template_variables(self, context, data_dict):
         return
-

--- a/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
@@ -17,7 +17,7 @@
 
 {% if pages %}
   {% set editor = h.get_wysiwyg_editor() %}
-  
+
     {% for page in pages %}
       {% if id %} {# this is for orgs and groups #}
         {% set url = h.url_for(controller='ckanext.pages.controller:PagesController', action=action, id=id, page='/' + page.name) %}
@@ -32,7 +32,7 @@
           <a style="background-image:url({{ page.image }})" href="{{ url }}">
           </a>
         </div>
-        <div class="span9">
+        <div class="span8">
            <h3 class="dataset-heading">
               <a href="{{ url }}" >{{ page.title }}</a>
               {% if page.publish_date %}
@@ -52,7 +52,7 @@
             {% endif %}
         </div>
       {% else %}
-        <div class="span12">
+        <div class="span11">
           <h3 class="dataset-heading">
             <a href="{{ url }}" >{{ page.title }}</a>
             {% if page.publish_date %}
@@ -74,7 +74,7 @@
       {% endif %}
       </div>
     {% endfor %}
-  
+
 {% else %}
     {% if type == 'blog' %}
       <p class="empty">{{ _('There are currently no blog articles here') }}</p>


### PR DESCRIPTION
I just closed #29, because there are actually a few more bugs I discovered just yesterday.

Wrong argument: in controller.py line 269.

datetime in json: in action.py, _page_list method, datetime is put directly inside a json file to be returned. Datetime object is not json serializable, so it is a better idea to convert it first.

API broken: all GET methods that do not specify side_effect_free to true will throw an exception in CKAN, so I propose to add decorator for all the GET methods.