### PR TITLE
Use get_uploader if ckan version is 2.5 or up

### DIFF
--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -184,7 +184,11 @@ def pages_upload(context, data_dict):
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
 
-    upload = uploader.Upload('page_images')
+    if p.toolkit.check_ckan_version(min_version='2.5'):
+        upload = uploader.get_uploader('page_images')
+    else:
+        upload = uploader.Upload('page_images')
+
     upload.update_data_dict(data_dict, 'image_url',
                             'upload', 'clear_upload')
     upload.upload()


### PR DESCRIPTION
Currently uploading pictures defaults to using local storage path only. Since 2.5 the ckan.lib.uploader.get_uploader method allows to use an extended uploader, for example using ckanext-s3filestore. 