### PR TITLE
Fix namespace_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 	url='',
 	license='',
 	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext', 'ckanext.pages'],
+	namespace_packages=['ckanext'],
 	include_package_data=True,
 	package_data={
             '': ['theme/*/*.html', 'theme/*/*/*.html', 'theme/*/*/*/*.html'],


### PR DESCRIPTION
Fixes plugin's setup.py namespace_packages to match the updated setup.py paster template. Fixes the issue mentioned in e.g. here: https://github.com/ckan/ckan/issues/2893