### PR TITLE
Fixed crash with accents in page title

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -48,9 +48,9 @@ def build_pages_nav_main(*args):
 
     for page in pages_list:
         if page['page_type'] == 'blog':
-            link = h.literal('<a href="/blog/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/blog/%s">%s</a>' % (unicode(page['name']), unicode(page['title'])))
         else:
-            link = h.literal('<a href="/pages/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/pages/%s">%s</a>' % (unicode(page['name']), unicode(page['title'])))
 
         if page['name'] == page_name:
             li = h.literal('<li class="active">') + link + h.literal('</li>')


### PR DESCRIPTION
The str() method gives me an encoding error when i try to use brazilian accentuation (á, ã, ê). Changing to unicode() corrected the problem.