### PR TITLE
Fixed crash with accents in page title

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -48,9 +48,9 @@ def build_pages_nav_main(*args):
 
     for page in pages_list:
         if page['page_type'] == 'blog':
-            link = h.literal('<a href="/blog/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/blog/%s">%s</a>' % (page['name'].encode('ascii'), page['title'].encode('ascii', 'xmlcharrefreplace')))
         else:
-            link = h.literal('<a href="/pages/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/pages/%s">%s</a>' % (page['name'].encode('ascii'), page['title'].encode('ascii', 'xmlcharrefreplace')))
 
         if page['name'] == page_name:
             li = h.literal('<li class="active">') + link + h.literal('</li>')


### PR DESCRIPTION
Hi,
I was getting this error after adding a page with a accent in the name (développeurs):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 45: ordinal not in range(128)

I'm not really used to python but the modifications from this PR solved the issue (in my case at least).

Regards