### PR TITLE
Fix for ckan compatibility with older CKANs

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -7,6 +7,7 @@ import ckan.plugins as p
 import ckan.lib.helpers as h
 import actions
 import auth
+import ckan
 
 if p.toolkit.check_ckan_version(min_version='2.5'):
     from ckan.lib.plugins import DefaultTranslation
@@ -91,12 +92,12 @@ def get_recent_blog_posts(number=5, exclude=None):
 
 
 def get_plus_icon():
-    ckan_version = float(h.ckan_version()[0:3])
+    ckan_version = float(ckan.__version__[0:3])
     if ckan_version >= 2.7:
         icon = 'plus-square'
     else:
         icon = 'plus-sign-alt'
-        
+
     return icon
 
 


### PR DESCRIPTION
There is a problem with [last PR](https://github.com/ckan/ckanext-pages/commit/fae750587970d190fc5547a2c323bc11b3858957) related to compatibility with older CKANs, for CKAN lower then 2.7, there is no such helper **ckan_version**, so it throws an error.

I guess it would be better to get version right from the ckan module as it done through all site.