### PR TITLE
[#58] Fix CKAN version check on older versions

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -8,7 +8,7 @@ import ckan.lib.helpers as h
 import actions
 import auth
 
-if p.toolkit.check_ckan_version(min_version='2.5'):
+if toolkit.check_ckan_version(min_version='2.5'):
     from ckan.lib.plugins import DefaultTranslation
 
     class PagesPluginBase(p.SingletonPlugin, DefaultTranslation):
@@ -21,9 +21,9 @@ log = logging.getLogger(__name__)
 
 def build_pages_nav_main(*args):
 
-    about_menu = p.toolkit.asbool(config.get('ckanext.pages.about_menu', True))
-    group_menu = p.toolkit.asbool(config.get('ckanext.pages.group_menu', True))
-    org_menu = p.toolkit.asbool(config.get('ckanext.pages.organization_menu', True))
+    about_menu = toolkit.asbool(config.get('ckanext.pages.about_menu', True))
+    group_menu = toolkit.asbool(config.get('ckanext.pages.group_menu', True))
+    org_menu = toolkit.asbool(config.get('ckanext.pages.organization_menu', True))
 
     new_args = []
     for arg in args:
@@ -38,13 +38,13 @@ def build_pages_nav_main(*args):
     output = h.build_nav_main(*new_args)
 
     # do not display any private datasets in menu even for sysadmins
-    pages_list = p.toolkit.get_action('ckanext_pages_list')(None, {'order': True, 'private': False})
+    pages_list = toolkit.get_action('ckanext_pages_list')(None, {'order': True, 'private': False})
 
     page_name = ''
 
-    if (p.toolkit.c.action in ('pages_show', 'blog_show')
-       and p.toolkit.c.controller == 'ckanext.pages.controller:PagesController'):
-        page_name = p.toolkit.c.environ['routes.url'].current().split('/')[-1]
+    if (toolkit.c.action in ('pages_show', 'blog_show')
+       and toolkit.c.controller == 'ckanext.pages.controller:PagesController'):
+        page_name = toolkit.c.environ['routes.url'].current().split('/')[-1]
 
     for page in pages_list:
         if page['page_type'] == 'blog':
@@ -62,7 +62,7 @@ def build_pages_nav_main(*args):
 
 
 def render_content(content):
-    allow_html = p.toolkit.asbool(config.get('ckanext.pages.allow_html', False))
+    allow_html = toolkit.asbool(config.get('ckanext.pages.allow_html', False))
     try:
         return h.render_markdown(content, allow_html=allow_html)
     except TypeError:
@@ -75,7 +75,7 @@ def get_wysiwyg_editor():
 
 
 def get_recent_blog_posts(number=5, exclude=None):
-    blog_list = p.toolkit.get_action('ckanext_pages_list')(
+    blog_list = toolkit.get_action('ckanext_pages_list')(
         None, {'order_publish_date': True, 'private': False,
                'page_type': 'blog'}
     )
@@ -91,13 +91,9 @@ def get_recent_blog_posts(number=5, exclude=None):
 
 
 def get_plus_icon():
-    ckan_version = float(h.ckan_version()[0:3])
-    if ckan_version >= 2.7:
-        icon = 'plus-square'
-    else:
-        icon = 'plus-sign-alt'
-        
-    return icon
+    if toolkit.check_ckan_version(min_version='2.7'):
+        return 'plus-square'
+    return 'plus-sign-alt'
 
 
 class PagesPlugin(PagesPluginBase):
@@ -110,21 +106,21 @@ class PagesPlugin(PagesPluginBase):
 
 
     def update_config(self, config):
-        self.organization_pages = p.toolkit.asbool(config.get('ckanext.pages.organization', False))
-        self.group_pages = p.toolkit.asbool(config.get('ckanext.pages.group', False))
+        self.organization_pages = toolkit.asbool(config.get('ckanext.pages.organization', False))
+        self.group_pages = toolkit.asbool(config.get('ckanext.pages.group', False))
 
-        p.toolkit.add_template_directory(config, 'theme/templates_main')
+        toolkit.add_template_directory(config, 'theme/templates_main')
         if self.group_pages:
-            p.toolkit.add_template_directory(config, 'theme/templates_group')
+            toolkit.add_template_directory(config, 'theme/templates_group')
         if self.organization_pages:
-            p.toolkit.add_template_directory(config, 'theme/templates_organization')
+            toolkit.add_template_directory(config, 'theme/templates_organization')
 
-        p.toolkit.add_resource('fanstatic', 'pages')
-        p.toolkit.add_public_directory(config, 'public')
+        toolkit.add_resource('fanstatic', 'pages')
+        toolkit.add_public_directory(config, 'public')
 
-        p.toolkit.add_resource('theme/public', 'ckanext-pages')
-        p.toolkit.add_resource('theme/resources', 'pages-theme')
-        p.toolkit.add_public_directory(config, 'theme/public')
+        toolkit.add_resource('theme/public', 'ckanext-pages')
+        toolkit.add_resource('theme/resources', 'pages-theme')
+        toolkit.add_public_directory(config, 'theme/public')
 
     def configure(self, config):
         return
@@ -233,8 +229,8 @@ class TextBoxView(p.SingletonPlugin):
     p.implements(p.IResourceView, inherit=True)
 
     def update_config(self, config):
-        p.toolkit.add_resource('textbox/theme', 'textbox')
-        p.toolkit.add_template_directory(config, 'textbox/templates')
+        toolkit.add_resource('textbox/theme', 'textbox')
+        toolkit.add_template_directory(config, 'textbox/templates')
 
     def info(self):
         schema = {

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -9,9 +9,9 @@ except ImportError:
 from ckanext.pages import db
 
 
-class TestUpdate(helpers.FunctionalTestBase):
+class TestPages(helpers.FunctionalTestBase):
     def setup(self):
-        super(TestUpdate, self).setup()
+        super(TestPages, self).setup()
         if db.pages_table is None:
             db.init_db(model)
         self.user = factories.Sysadmin()
@@ -68,3 +68,33 @@ class TestUpdate(helpers.FunctionalTestBase):
         assert_in('<h1 class="page-heading">Disallowed</h1>', response.body)
         assert_in('Test Link', response.body)
         assert_not_in('<a href="/test">Test Link</a>', response.body)
+
+    def test_pages_index(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        url = toolkit.url_for('pages_index')
+        response = self.app.get(url, status=200, extra_environ=env)
+        assert_in('<h2>Pages</h2>', response.body)
+        assert_in('Add page</a>', response.body)
+
+    def test_blog_index(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        url = toolkit.url_for('blog_index')
+        response = self.app.get(url, status=200, extra_environ=env)
+        assert_in('<h2>Blog</h2>', response.body)
+        assert_in('Add Article</a>', response.body)
+
+    def test_organization_pages_index(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        org = factories.Organization()
+        url = toolkit.url_for('organization_pages_index', id=org['id'])
+        response = self.app.get(url, status=200, extra_environ=env)
+        assert_in('<h2>Pages</h2>', response.body)
+        assert_in('Add page</a>', response.body)
+
+    def test_group_pages_index(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        group = factories.Group()
+        url = toolkit.url_for('group_pages_index', id=group['id'])
+        response = self.app.get(url, status=200, extra_environ=env)
+        assert_in('<h2>Pages</h2>', response.body)
+        assert_in('Add page</a>', response.body)

--- a/test.ini
+++ b/test.ini
@@ -2,3 +2,7 @@
 use = config:../ckan/test-core.ini
 
 ckan.plugins = pages
+
+ckanext.pages.organization = True
+ckanext.pages.group = True
+


### PR DESCRIPTION
Fixes #58 by replacing the version check using `h.ckan_version` with `toolkit.check_ckan_version`.