### PR TITLE
[#53] Cannot delete org and group pages

### DIFF
--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -7,10 +7,6 @@ _ = p.toolkit._
 class PagesController(p.toolkit.BaseController):
     controller = 'ckanext.pages.controller:PagesController'
 
-    def _get_group_dict(self, id):
-        ''' returns the result of group_show action or aborts if there is a
-        problem '''
-
     def _template_setup_org(self, id):
         if not id:
             return
@@ -49,23 +45,22 @@ class PagesController(p.toolkit.BaseController):
         self._template_setup_org(id)
         page = page[1:]
         if 'cancel' in p.toolkit.request.params:
-            p.toolkit.redirect_to(controller=self.controller, action='org_edit', id=p.toolkit.c.group_dict['name'], page='/' + page)
-
-  ##      try:
-  ##          self._check_access('group_delete', {}, {'id': id})
-  ##      except p.toolkit.NotAuthorized:
-  ##          p.toolkit.abort(401, _('Unauthorized to delete page'))
-
+            p.toolkit.redirect_to(controller=self.controller,
+                                  action='org_edit',
+                                  id=p.toolkit.c.group_dict['name'],
+                                  page='/' + page)
         try:
             if p.toolkit.request.method == 'POST':
-                p.toolkit.get_action('ckanext_pages_delete')({}, {'org_id': p.toolkit.c.group_dict['id'], 'page': page})
+                action = p.toolkit.get_action('ckanext_pages_delete')
+                action({}, {'org_id': p.toolkit.c.group_dict['id'],
+                       'page': page})
                 p.toolkit.redirect_to('organization_pages_index', id=id)
             else:
                 p.toolkit.abort(404, _('Page Not Found'))
         except p.toolkit.NotAuthorized:
             p.toolkit.abort(401, _('Unauthorized to delete page'))
         except p.toolkit.ObjectNotFound:
-            p.toolkit.abort(404, _('Group not found'))
+            p.toolkit.abort(404, _('Organization not found'))
         return p.toolkit.render('ckanext_pages/confirm_delete.html', {'page': page})
 
 
@@ -139,6 +134,30 @@ class PagesController(p.toolkit.BaseController):
             return self._group_list_pages(id)
         p.toolkit.c.page = _page
         return p.toolkit.render('ckanext_pages/group_page.html')
+
+
+    def group_delete(self, id, page):
+        self._template_setup_group(id)
+        page = page[1:]
+        if 'cancel' in p.toolkit.request.params:
+            p.toolkit.redirect_to(controller=self.controller,
+                                  action='group_edit',
+                                  id=p.toolkit.c.group_dict['name'],
+                                  page='/' + page)
+        try:
+            if p.toolkit.request.method == 'POST':
+                action = p.toolkit.get_action('ckanext_pages_delete')
+                action({}, {'org_id': p.toolkit.c.group_dict['id'],
+                       'page': page})
+                p.toolkit.redirect_to('group_pages_index', id=id)
+            else:
+                p.toolkit.abort(404, _('Page Not Found'))
+        except p.toolkit.NotAuthorized:
+            p.toolkit.abort(401, _('Unauthorized to delete page'))
+        except p.toolkit.ObjectNotFound:
+            p.toolkit.abort(404, _('Group not found'))
+        return p.toolkit.render('ckanext_pages/confirm_delete.html', {'page': page})
+
 
     def _group_list_pages(self, id):
         p.toolkit.c.pages_dict = p.toolkit.get_action('ckanext_pages_list')(

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -5,35 +5,26 @@
 {% set errors = errors or {} %}
 
 {% if type == 'org' %}
-  {% set action_url = h.url_for('organization_pages_edit', id=id, page='/' + page) %}
-  {% set cancel_url = h.url_for('organization_pages_index', id=id) %}
-  {% set slug_prefix = cancel_url ~ '/' %}
-  {% set slug_domain = h.url_for('organization_pages_index', id=id, qualified=true) %}
-  {% set hide_field_order = true %}
+    {% set prefix = 'organization_pages_' %}
+    {% set args = {'id': id} %}
 {% elif type == 'group' %}
-  {% set action_url = h.url_for('group_pages_edit', id=id, page='/' + page) %}
-  {% set cancel_url = h.url_for('group_pages_index', id=id) %}
-  {% set slug_prefix = cancel_url ~ '/' %}
-  {% set slug_domain = h.url_for('group_pages_index', id=id, qualified=true) %}
-  {% set hide_field_order = true %}
+    {% set prefix = 'group_pages_' %}
+    {% set args = {'id': id} %}
 {% elif type == 'blog' %}
-  {% set action_url = h.url_for('blog_edit', page='/' + page) %}
-  {% set cancel_url = h.url_for('blog_index') %}
-  {% set slug_prefix = cancel_url ~ '/' %}
-  {% set slug_domain = h.url_for('blog_index', qualified=true) %}
-  {% if page %}
-     {% set delete_url = h.url_for('blog_delete', page='/' + data.name) %}
-  {% endif %}
+    {% set prefix = 'blog_' %}
+    {% set args = {} %}
 {% else %}
-  {% set action_url = h.url_for('pages_edit', page='/' + page) %}
-  {% set cancel_url = h.url_for('pages_index') %}
-  {% set slug_prefix = cancel_url ~ '/' %}
-  {% set slug_domain = h.url_for('pages_index', qualified=true) %}
-  {% if page %}
-     {% set delete_url = h.url_for('pages_delete', page='/' + data.name) %}
-  {% endif %}
+    {% set prefix = 'pages_' %}
+    {% set args = {} %}
 {% endif %}
-
+{% set page_url = '/' + page %}
+{% set action_url = h.url_for(prefix + 'edit', page=page_url, **args) %}
+{% set cancel_url = h.url_for(prefix + 'index', **args) %}
+{% set slug_prefix = cancel_url ~ '/' %}
+{% set slug_domain = h.url_for(prefix + 'index', qualified=true, **args) %}
+{% if page %}
+   {% set delete_url = h.url_for(prefix + 'delete', page=page_url, **args) %}
+{% endif %}
 
 {% if type == 'blog' %}
     {% if not page %}


### PR DESCRIPTION
Fixes #53.

The delete buttons on group and organization pages had incorrect URLs. In addition, the controller for deleting group pages was completely missing.