### PR TITLE
Increase size of plain text editor

### DIFF
--- a/ckanext/pages/theme/resources/styles/pages.css
+++ b/ckanext/pages/theme/resources/styles/pages.css
@@ -4,7 +4,6 @@
 .page-list-item .image {
   width: 168px;
   /* hack for default theme */
-
 }
 .page-list-item .image a {
   display: block;
@@ -14,4 +13,7 @@
 }
 .page-list-item h3 a {
   display: block;
+}
+.page-simple-form-height {
+  height: 400px !important;
 }

--- a/ckanext/pages/theme/resources/styles/pages.less
+++ b/ckanext/pages/theme/resources/styles/pages.less
@@ -14,3 +14,6 @@
 .page-list-item h3 a {
 	display:block;
 }
+.page-simple-form-height {
+  height: 400px !important;
+}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -103,7 +103,7 @@
     </div>
     <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
   {% else %}
-    {{ form.markdown('content', id='field-content', label=_('Content'), placeholder=_('Enter content here'), value=data.content, error=errors.content) }}
+    {{ form.markdown('content', id='field-content', attrs={'class': 'form-control page-simple-form-height'}, label=_('Content'), placeholder=_('Enter content here'), value=data.content, error=errors.content) }}
   {% endif %}
 
   <div class="form-actions">


### PR DESCRIPTION
Pages' markdown editor for plain text editing is calling the same form that CKAN uses for small things. But as pages tend to be longer, some more space would be nice. This PR creates a new CSS class and passes it through to make the textarea larger.