### PR TITLE
Fix group/org pages update permissions

### DIFF
--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -242,8 +242,10 @@ def org_pages_show(context, data_dict):
 
 
 def org_pages_update(context, data_dict):
+    org_id = data_dict.get('org_id')
     try:
-        p.toolkit.check_access('ckanext_org_pages_update', context, data_dict)
+        p.toolkit.check_access('ckanext_org_pages_update', context,
+                               {'id': org_id})
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
@@ -274,8 +276,10 @@ def group_pages_show(context, data_dict):
 
 
 def group_pages_update(context, data_dict):
+    group_id = data_dict.get('org_id')
     try:
-        p.toolkit.check_access('ckanext_group_pages_update', context, data_dict)
+        p.toolkit.check_access('ckanext_group_pages_update', context,
+                               {'id': group_id})
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -242,10 +242,9 @@ def org_pages_show(context, data_dict):
 
 
 def org_pages_update(context, data_dict):
-    org_id = data_dict.get('org_id')
     try:
         p.toolkit.check_access('ckanext_org_pages_update', context,
-                               {'id': org_id})
+                               data_dict)
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
@@ -253,7 +252,8 @@ def org_pages_update(context, data_dict):
 
 def org_pages_delete(context, data_dict):
     try:
-        p.toolkit.check_access('ckanext_org_pages_delete', context, data_dict)
+        p.toolkit.check_access('ckanext_org_pages_delete', context,
+                               data_dict)
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
@@ -276,10 +276,9 @@ def group_pages_show(context, data_dict):
 
 
 def group_pages_update(context, data_dict):
-    group_id = data_dict.get('org_id')
     try:
         p.toolkit.check_access('ckanext_group_pages_update', context,
-                               {'id': group_id})
+                               data_dict)
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_update(context, data_dict)
@@ -287,7 +286,8 @@ def group_pages_update(context, data_dict):
 
 def group_pages_delete(context, data_dict):
     try:
-        p.toolkit.check_access('ckanext_group_pages_delete', context, data_dict)
+        p.toolkit.check_access('ckanext_group_pages_delete', context,
+                               data_dict)
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)

--- a/ckanext/pages/auth.py
+++ b/ckanext/pages/auth.py
@@ -33,6 +33,16 @@ def org_admin(context, data_dict):
     }
 
 
+def page_group_admin(context, data_dict):
+    group_id = data_dict.get('org_id')
+    if not group_id:
+        id = data_dict.get('id')
+        page = data_dict.get('page') or db.Page.get(id=id)
+        if page:
+            group_id = page.group_id
+    return group_admin(context, {'id': group_id})
+
+
 def page_privacy(context, data_dict):
     if db.pages_table is None:
         db.init_db(context['model'])
@@ -72,10 +82,10 @@ pages_delete = sysadmin
 pages_list = anyone
 pages_upload = sysadmin
 org_pages_show = page_privacy
-org_pages_update = org_admin
-org_pages_delete = org_admin
+org_pages_update = page_group_admin
+org_pages_delete = page_group_admin
 org_pages_list = anyone
 group_pages_show = page_privacy
-group_pages_update = group_admin
-group_pages_delete = group_admin
+group_pages_update = page_group_admin
+group_pages_delete = page_group_admin
 group_pages_list = anyone

--- a/ckanext/pages/auth.py
+++ b/ckanext/pages/auth.py
@@ -22,11 +22,15 @@ if p.toolkit.check_ckan_version(min_version='2.2'):
 
 
 def group_admin(context, data_dict):
-    return p.toolkit.check_access('group_update', context, data_dict)
+    return {
+        'success': p.toolkit.check_access('group_update', context, data_dict)
+    }
 
 
 def org_admin(context, data_dict):
-    return p.toolkit.check_access('group_update', context, data_dict)
+    return {
+        'success': p.toolkit.check_access('group_update', context, data_dict)
+    }
 
 
 def page_privacy(context, data_dict):

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -53,7 +53,7 @@ class PagesController(p.toolkit.BaseController):
                                   page='/' + page)
         try:
             if p.toolkit.request.method == 'POST':
-                action = p.toolkit.get_action('ckanext_pages_delete')
+                action = p.toolkit.get_action('ckanext_org_pages_delete')
                 action({}, {'org_id': p.toolkit.c.group_dict['id'],
                        'page': page})
                 p.toolkit.redirect_to('organization_pages_index', id=id)
@@ -151,7 +151,7 @@ class PagesController(p.toolkit.BaseController):
                                   page='/' + page)
         try:
             if p.toolkit.request.method == 'POST':
-                action = p.toolkit.get_action('ckanext_pages_delete')
+                action = p.toolkit.get_action('ckanext_group_pages_delete')
                 action({}, {'org_id': p.toolkit.c.group_dict['id'],
                        'page': page})
                 p.toolkit.redirect_to('group_pages_index', id=id)

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -32,13 +32,15 @@ class PagesController(p.toolkit.BaseController):
         if _page is None:
             return self._org_list_pages(id)
         p.toolkit.c.page = _page
-        return p.toolkit.render('ckanext_pages/organization_page.html')
+        return p.toolkit.render('ckanext_pages/organization_page.html',
+                                {'group_type': 'organization'})
 
     def _org_list_pages(self, id):
         p.toolkit.c.pages_dict = p.toolkit.get_action('ckanext_pages_list')(
             data_dict={'org_id': p.toolkit.c.group_dict['id']}
         )
-        return p.toolkit.render('ckanext_pages/organization_page_list.html')
+        return p.toolkit.render('ckanext_pages/organization_page_list.html',
+                                {'group_type': 'organization'})
 
 
     def org_delete(self, id, page):
@@ -61,7 +63,8 @@ class PagesController(p.toolkit.BaseController):
             p.toolkit.abort(401, _('Unauthorized to delete page'))
         except p.toolkit.ObjectNotFound:
             p.toolkit.abort(404, _('Organization not found'))
-        return p.toolkit.render('ckanext_pages/confirm_delete.html', {'page': page})
+        return p.toolkit.render('ckanext_pages/confirm_delete.html',
+                                {'page': page, 'group_type': 'organization'})
 
 
     def org_edit(self, id, page=None, data=None, errors=None, error_summary=None):
@@ -70,7 +73,7 @@ class PagesController(p.toolkit.BaseController):
             page = page[1:]
         _page = p.toolkit.get_action('ckanext_pages_show')(
             data_dict={'org_id': p.toolkit.c.group_dict['id'],
-                       'page': page,}
+                       'page': page}
         )
         if _page is None:
             _page = {}
@@ -82,10 +85,10 @@ class PagesController(p.toolkit.BaseController):
             for item in items:
                 if item in data:
                     _page[item] = data[item]
-            _page['org_id'] = p.toolkit.c.group_dict['id'],
+            _page['org_id'] = p.toolkit.c.group_dict['id']
             _page['page'] = page
             try:
-                junk = p.toolkit.get_action('ckanext_pages_update')(
+                junk = p.toolkit.get_action('ckanext_org_pages_update')(
                     data_dict=_page
                 )
             except p.toolkit.ValidationError, e:
@@ -102,7 +105,8 @@ class PagesController(p.toolkit.BaseController):
         error_summary = error_summary or {}
 
         vars = {'data': data, 'errors': errors,
-                'error_summary': error_summary, 'page': page}
+                'error_summary': error_summary, 'page': page,
+                'group_type': 'organization'}
 
         return p.toolkit.render('ckanext_pages/organization_page_edit.html',
                                extra_vars=vars)
@@ -128,12 +132,13 @@ class PagesController(p.toolkit.BaseController):
             return self._group_list_pages(id)
         _page = p.toolkit.get_action('ckanext_pages_show')(
             data_dict={'org_id': p.toolkit.c.group_dict['id'],
-                       'page': page,}
+                       'page': page}
         )
         if _page is None:
             return self._group_list_pages(id)
         p.toolkit.c.page = _page
-        return p.toolkit.render('ckanext_pages/group_page.html')
+        return p.toolkit.render('ckanext_pages/group_page.html',
+                                {'group_type': 'group'})
 
 
     def group_delete(self, id, page):
@@ -156,14 +161,16 @@ class PagesController(p.toolkit.BaseController):
             p.toolkit.abort(401, _('Unauthorized to delete page'))
         except p.toolkit.ObjectNotFound:
             p.toolkit.abort(404, _('Group not found'))
-        return p.toolkit.render('ckanext_pages/confirm_delete.html', {'page': page})
+        return p.toolkit.render('ckanext_pages/confirm_delete.html',
+                                {'page': page, 'group_type': 'group'})
 
 
     def _group_list_pages(self, id):
         p.toolkit.c.pages_dict = p.toolkit.get_action('ckanext_pages_list')(
             data_dict={'org_id': p.toolkit.c.group_dict['id']}
         )
-        return p.toolkit.render('ckanext_pages/group_page_list.html')
+        return p.toolkit.render('ckanext_pages/group_page_list.html',
+                                {'group_type': 'group'})
 
     def group_edit(self, id, page=None, data=None, errors=None, error_summary=None):
         self._template_setup_group(id)
@@ -171,7 +178,7 @@ class PagesController(p.toolkit.BaseController):
             page = page[1:]
         _page = p.toolkit.get_action('ckanext_pages_show')(
             data_dict={'org_id': p.toolkit.c.group_dict['id'],
-                       'page': page,}
+                       'page': page}
         )
         if _page is None:
             _page = {}
@@ -186,7 +193,7 @@ class PagesController(p.toolkit.BaseController):
             _page['org_id'] = p.toolkit.c.group_dict['id']
             _page['page'] = page
             try:
-                junk = p.toolkit.get_action('ckanext_pages_update')(
+                junk = p.toolkit.get_action('ckanext_group_pages_update')(
                     data_dict=_page
                 )
             except p.toolkit.ValidationError, e:
@@ -203,7 +210,8 @@ class PagesController(p.toolkit.BaseController):
         error_summary = error_summary or {}
 
         vars = {'data': data, 'errors': errors,
-                'error_summary': error_summary, 'page': page}
+                'error_summary': error_summary, 'page': page,
+                'group_type': 'group'}
 
         return p.toolkit.render('ckanext_pages/group_page_edit.html',
                                extra_vars=vars)

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -104,7 +104,7 @@
     {% else %}
 
       {% block delete_button %}
-        {% if h.check_access('ckanext_pages_delete', {'id': data.id})  %}
+        {% if h.check_access('ckanext_%spages_delete'|format(type ~ '_' if type in ('group', 'org') else ''), {'id': data.id})  %}
           {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Page?')}) %}
           <a class="btn btn-danger pull-left" href="{{ delete_url }}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/group_page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/group_page.html
@@ -3,7 +3,9 @@
 {% block subtitle %}{{ _('Pages') }} - {{ c.group_dict.display_name }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='group_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+    {% if h.check_access('ckanext_group_pages_update', {'id': c.page.id}) %}
+        {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='group_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+    {% endif %}
   <h1 class="page-heading">{{ c.page.title }}</h1>
   {% if c.page.content %}
     {% set editor = h.get_wysiwyg_editor() %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/organization_page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/organization_page.html
@@ -3,7 +3,9 @@
 {% block subtitle %}{{ _('Pages') }} - {{ c.group_dict.display_name }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='org_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+    {% if h.check_access('ckanext_org_pages_update', {'id': c.page.id}) %}
+        {% link_for _('Edit page'), controller='ckanext.pages.controller:PagesController', action='org_edit', id=c.group_dict.name, page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+    {% endif %}
   <h1 class="page-heading">{{ c.page.title }}</h1>
   {% if c.page.content %}
     {% set editor = h.get_wysiwyg_editor() %}


### PR DESCRIPTION
Currently, page edit form for both organization and group pages calls `pages_update` function, that requires sysadmin account.  As a result, organization admins(not sysadmins) will be logged out after an attempt to update the organization's page.

This PR updates permission checks as well as fixes few small problems(for example, group/org edit auth checks were returning boolean instead of dict in form `{'success': boolean}`)