### PR TITLE
Remove extraneous tags added by lxml that prevent proper rendering

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -44,6 +44,9 @@ echo "Installing ckanext-pages and its requirements..."
 python setup.py develop
 pip install -r dev-requirements.txt
 
+echo "Install lxml to enable all functionality"
+pip install lxml
+
 echo "Moving test.ini into a subdir..."
 mkdir subdir
 mv test.ini subdir

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -270,8 +270,16 @@ class PagesController(p.toolkit.BaseController):
             view_element = lxml.html.fromstring(resource_view_html)
             element.append(view_element)
 
-        _page['content'] = lxml.html.tostring(root)
-
+        new_content = lxml.html.tostring(root)
+        if new_content.startswith('<div>') and new_content.endswith('</div>'):
+            # lxml will add a <div> tag to text that starts with an HTML tag,
+            # which will cause the rendering to fail
+            new_content = new_content[5:-6]
+        elif new_content.startswith('<p>') and new_content.endswith('</p>'):
+            # lxml will add a <p> tag to plain text snippet, which will cause the
+            # rendering to fail
+            new_content = new_content[3:-4]
+        _page['content'] = new_content
 
 
     def pages_show(self, page=None, page_type='page'):

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -71,6 +71,37 @@ class TestPages(helpers.FunctionalTestBase):
         assert_in('Test Link', response.body)
         assert_not_in('<a href="/test">Test Link</a>', response.body)
 
+    @helpers.change_config('ckanext.pages.allow_html', False)
+    def test_rendering_no_p_tags_added_with_html_disallowed(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        response = self.app.post(
+            url=toolkit.url_for('pages_edit', page='/test_html_page_p'),
+            params={
+                'title': 'Disallowed',
+                'name': 'page_html_disallowed_p',
+                'content': 'Hi there **you**',
+            },
+            extra_environ=env,
+        )
+        response = response.follow(extra_environ=env)
+        assert_in('<p>Hi there <strong>you</strong></p>', response.body)
+
+    @helpers.change_config('ckanext.pages.allow_html', True)
+    def test_rendering_no_div_tags_added_with_html_allowed(self):
+        env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        response = self.app.post(
+            url=toolkit.url_for('pages_edit', page='/test_html_page_div'),
+            params={
+                'title': 'Disallowed',
+                'name': 'page_html_allowed_div',
+                'content': '<p>Hi there</p>',
+            },
+            extra_environ=env,
+        )
+        response = response.follow(extra_environ=env)
+        assert_in('<p>Hi there</p>', response.body)
+        assert_not_in('<div><p>Hi there</p></div>', response.body)
+
     def test_pages_index(self):
         env = {'REMOTE_USER': self.user['name'].encode('ascii')}
         url = toolkit.url_for('pages_index')

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page.html
@@ -11,6 +11,7 @@
     {% if c.page.content %}
       <div class="ckanext-pages-content">
         {% set editor = h.get_wysiwyg_editor() %}
+        <!-- editor set to "{{ editor }}"-->
         {% if editor %}
           <div>
               {{c.page.content|safe}}

--- a/test.ini
+++ b/test.ini
@@ -1,7 +1,7 @@
 [app:main]
 use = config:../ckan/test-core.ini
 
-ckan.plugins = pages
+ckan.plugins = pages image_view
 
 ckanext.pages.organization = True
 ckanext.pages.group = True


### PR DESCRIPTION
If lxml is enabled, the `_inject_views_into_page` method of the controller does some tweaking of the HTML tree. If the content passed is a text snippet (like 99.99% of the markdown content passed) it will wrap it on `<p>` tags (or if the snippet starts with a `<p>` tag, with a `<div>` tag). This will cause the snippet to not be properly rendered.

