### PR TITLE
Adding configuration for CKEditor to render styles in the editor

### DIFF
--- a/ckanext/pages/theme/public/ckedit.js
+++ b/ckanext/pages/theme/public/ckedit.js
@@ -39,6 +39,7 @@ this.ckan.module('ckedit', function (jQuery, _) {
       config.extraPlugins = 'divarea,ckanview,templates';
       config.height = '400px';
       config.customConfig = false;
+      config.allowedContent = true;
 
       var editor = $(this.el).ckeditor(config);
     },


### PR DESCRIPTION
This PR fixes a bug that caused styles to not being properly displayed in ckeditor when editing pages/blogs. The following gif shows the behavior to fix.

![index](https://user-images.githubusercontent.com/60520297/77001781-b6303b80-6917-11ea-9e3a-a2cad5d46fc6.gif)

To solve it I added a new config based on the solution proposed [here.](https://stackoverflow.com/a/18756230) 
