### PR TITLE
Adding flash_error message in case of missing values

### DIFF
--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -407,6 +407,7 @@ class PagesController(p.toolkit.BaseController):
             except p.toolkit.ValidationError, e:
                 errors = e.error_dict
                 error_summary = e.error_summary
+                p.toolkit.h.flash_error(error_summary)
                 return self.pages_edit('/' + page, data,
                                        errors, error_summary, page_type=page_type)
             p.toolkit.redirect_to('%s_show' % page_type, page='/' + _page['name'])


### PR DESCRIPTION
The dictization_functions only sets error keys for missing or validation error in the form. If there is an error not related to the form, it neither gets displayed in the browser neither on the terminal.
The issue is that the pages extension self redirects to the edit pages link in the case of the exception rather than raising it. It redirects to the edit page with an error dictionary that gets displayed in the browser similar to when you try to add a page without a title, it will not raise an exception in the terminal although it will show the error in the browser like 'Missing Value'.
This PR will add a flash message of the error summary at the top of the page to get notified of the occurrence of an error.