### PR TITLE
Fix for blog view issue if more then one blog is created on CKAN 2.9

### DIFF
--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog.html
@@ -42,7 +42,11 @@
         {% for post in posts %}
             <div class="blog-title">
                 <h3 class="dataset-heading">
-                    <a href="{{ h.url_for(controller='ckanext.pages.controller:PagesController', action='blog_show', page='/' + post.name) }}">{{ post.title or post.name }}</a>
+                    {% if h.ckan_version().split('.')[1] | int >= 9 %}
+                      <a href="{{ h.url_for('pages.blog_show', page='/' + post.name) }}">{{ post.title or post.name }}</a>
+                    {% else %}
+                      <a href="{{ h.url_for(controller='ckanext.pages.controller:PagesController', action='blog_show', page='/' + post.name) }}">{{ post.title or post.name }}</a>
+                    {% endif %}
                     <br>
                     {% if post.publish_date %}
                         <small> {{ h.render_datetime(post.publish_date) }} </small>
@@ -53,7 +57,11 @@
                 {{ h.markdown_extract(post.content) }}
                 {% if post.publish_date %}
                    <br>
-                   <a class="btn btn-small btn-primary more" href="{{ h.url_for(controller='ckanext.pages.controller:PagesController', action='blog_show', page='/' + post.name) }}">{{ _('More') }}</a>
+                    {% if h.ckan_version().split('.')[1] | int >= 9 %}
+                      <a class="btn btn-small btn-primary more" href="{{ h.url_for('pages.blog_show', page='/' + post.name) }}">{{ _('More') }}</a>
+                    {% else %}
+                      <a class="btn btn-small btn-primary more" href="{{ h.url_for(controller='ckanext.pages.controller:PagesController', action='blog_show', page='/' + post.name) }}">{{ _('More') }}</a>
+                    {% endif %}
                 {% endif %}
             </div>
         {% endfor %}


### PR DESCRIPTION
Fixes an issue when you try to view a blog and you have more the one blogs created on the portal. 
This is happens on CKAN 2.9+.