### PR TITLE
Move database initialization to cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
         run: pip install flake8 pycodestyle
       - name: Check syntax
         run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+      - name: Run flake8
+        run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
 
   test:
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,12 @@ jobs:
       if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' }}
       run: |
         ckan -c test.ini db init
+        ckan -c test.ini pages initdb
     - name: Setup extension (CKAN < 2.9)
       if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' }}
       run: |
         paster --plugin=ckan db init -c test.ini
+        paster --plugin=ckanext-pages pages initdb -c test.ini
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.pages --cov-report=xml --cov-append --disable-warnings ckanext/pages/tests
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Make sure to add `pages` to `ckan.plugins` in your config file:
 ckan.plugins = pages
 ```
 
+## Database initialization
+
+You need to initialize database from command line with the following commands:
+
+ON CKAN >= 2.9:
+```
+(pyenv) $ ckan --config=/etc/ckan/default/ckan.ini pages initdb
+```
+
+ON CKAN <= 2.8:
+```
+(pyenv) $ paster --plugin=ckanext-pages pages initdb --config=/etc/ckan/default/production.ini
+```
+
 ## Configuration
 
 

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -32,8 +32,6 @@ class HTMLFirstImage(HTMLParser):
 
 
 def _pages_show(context, data_dict):
-    if db.pages_table is None:
-        db.init_db(context['model'])
     org_id = data_dict.get('org_id')
     page = data_dict.get('page')
     out = db.Page.get(group_id=org_id, name=page)
@@ -44,8 +42,6 @@ def _pages_show(context, data_dict):
 
 def _pages_list(context, data_dict):
     search = {}
-    if db.pages_table is None:
-        db.init_db(context['model'])
     org_id = data_dict.get('org_id')
     ordered = data_dict.get('order')
     order_publish_date = data_dict.get('order_publish_date')
@@ -95,8 +91,6 @@ def _pages_list(context, data_dict):
     return out_list
 
 def _pages_delete(context, data_dict):
-    if db.pages_table is None:
-        db.init_db(context['model'])
     org_id = data_dict.get('org_id')
     page = data_dict.get('page')
     out = db.Page.get(group_id=org_id, name=page)
@@ -107,8 +101,6 @@ def _pages_delete(context, data_dict):
 
 
 def _pages_update(context, data_dict):
-    if db.pages_table is None:
-        db.init_db(context['model'])
     org_id = data_dict.get('org_id')
     page = data_dict.get('page')
     # we need the page in the context for name validation

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -81,7 +81,7 @@ def _pages_list(context, data_dict):
                   'publish_date': pg.publish_date.isoformat() if pg.publish_date else None,
                   'group_id': pg.group_id,
                   'page_type': pg.page_type,
-                 }
+                  }
         if img:
             pg_row['image'] = img
         extras = pg.extras
@@ -89,6 +89,7 @@ def _pages_list(context, data_dict):
             pg_row.update(json.loads(pg.extras))
         out_list.append(pg_row)
     return out_list
+
 
 def _pages_delete(context, data_dict):
     org_id = data_dict.get('org_id')
@@ -120,8 +121,10 @@ def _pages_update(context, data_dict):
         out.name = page
     items = ['title', 'content', 'name', 'private',
              'order', 'page_type', 'publish_date']
+
+    # backward compatible with older version where page_type does not exist
     for item in items:
-        setattr(out, item, data.get(item,'page' if item =='page_type' else None)) #backward compatible with older version where page_type does not exist
+        setattr(out, item, data.get(item, 'page' if item == 'page_type' else None))
 
     extras = {}
 
@@ -138,6 +141,7 @@ def _pages_update(context, data_dict):
     session = context['session']
     session.add(out)
     session.commit()
+
 
 def pages_upload(context, data_dict):
 
@@ -157,10 +161,11 @@ def pages_upload(context, data_dict):
     image_url = data_dict.get('image_url')
     if image_url and image_url[0:6] not in {'http:/', 'https:'}:
         image_url = h.url_for_static(
-           'uploads/page_images/%s' % image_url,
+            'uploads/page_images/%s' % image_url,
             qualified=True
         )
     return {'url': image_url, 'fileName': upload.filename, 'uploaded': 1}
+
 
 @tk.side_effect_free
 def pages_show(context, data_dict):
@@ -186,6 +191,7 @@ def pages_delete(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
 
+
 @tk.side_effect_free
 def pages_list(context, data_dict):
     try:
@@ -193,6 +199,7 @@ def pages_list(context, data_dict):
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_list(context, data_dict)
+
 
 @tk.side_effect_free
 def org_pages_show(context, data_dict):
@@ -220,6 +227,7 @@ def org_pages_delete(context, data_dict):
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
 
+
 @tk.side_effect_free
 def org_pages_list(context, data_dict):
     try:
@@ -227,6 +235,7 @@ def org_pages_list(context, data_dict):
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_list(context, data_dict)
+
 
 @tk.side_effect_free
 def group_pages_show(context, data_dict):
@@ -253,6 +262,7 @@ def group_pages_delete(context, data_dict):
     except p.toolkit.NotAuthorized:
         p.toolkit.abort(401, p.toolkit._('Not authorized to see this page'))
     return _pages_delete(context, data_dict)
+
 
 @tk.side_effect_free
 def group_pages_list(context, data_dict):

--- a/ckanext/pages/auth.py
+++ b/ckanext/pages/auth.py
@@ -44,8 +44,6 @@ def page_group_admin(context, data_dict):
 
 
 def page_privacy(context, data_dict):
-    if db.pages_table is None:
-        db.init_db(context['model'])
     org_id = data_dict.get('org_id')
     page = data_dict.get('page')
     out = db.Page.get(group_id=org_id, name=page)

--- a/ckanext/pages/auth.py
+++ b/ckanext/pages/auth.py
@@ -11,6 +11,7 @@ from ckanext.pages import db
 def sysadmin(context, data_dict):
     return {'success':  False}
 
+
 def anyone(context, data_dict):
     return {'success': True}
 
@@ -47,7 +48,7 @@ def page_privacy(context, data_dict):
     org_id = data_dict.get('org_id')
     page = data_dict.get('page')
     out = db.Page.get(group_id=org_id, name=page)
-    if out and out.private == False:
+    if out and out.private is False:
         return {'success':  True}
     # no org_id means it's a universal page
     if not org_id:
@@ -57,8 +58,8 @@ def page_privacy(context, data_dict):
     group = context['model'].Group.get(org_id)
     user = context['user']
     authorized = authz.has_user_permission_for_group_or_org(group.id,
-                                                                user,
-                                                                'read')
+                                                            user,
+                                                            'read')
     if not authorized:
         return {'success': False,
                 'msg': p.toolkit._(

--- a/ckanext/pages/blueprint.py
+++ b/ckanext/pages/blueprint.py
@@ -85,14 +85,20 @@ pages.add_url_rule("/blog_delete/<page>", view_func=blog_delete, endpoint='blog_
 
 pages.add_url_rule("/organization/pages/<id>", view_func=org_show, endpoint='organization_pages_index')
 pages.add_url_rule("/organization/pages/<id>/<page>", view_func=org_show, endpoint='organization_pages_show')
-pages.add_url_rule("/organization/pages_edit/<id>", view_func=org_edit, endpoint='organization_pages_new', methods=['GET', 'POST'])
-pages.add_url_rule("/organization/pages_edit/<id>/", view_func=org_edit, endpoint='organization_pages_new', methods=['GET', 'POST'])
-pages.add_url_rule("/organization/pages_edit/<id>/<page>", view_func=org_edit, endpoint='organization_pages_edit', methods=['GET', 'POST'])
-pages.add_url_rule("/organization/pages_delete/<id>/<page>", view_func=org_delete, endpoint='organization_pages_delete', methods=['GET', 'POST'])
+pages.add_url_rule("/organization/pages_edit/<id>", view_func=org_edit,
+                   endpoint='organization_pages_new', methods=['GET', 'POST'])
+pages.add_url_rule("/organization/pages_edit/<id>/", view_func=org_edit,
+                   endpoint='organization_pages_new', methods=['GET', 'POST'])
+pages.add_url_rule("/organization/pages_edit/<id>/<page>", view_func=org_edit,
+                   endpoint='organization_pages_edit', methods=['GET', 'POST'])
+pages.add_url_rule("/organization/pages_delete/<id>/<page>", view_func=org_delete,
+                   endpoint='organization_pages_delete', methods=['GET', 'POST'])
 
 pages.add_url_rule("/group/pages/<id>", view_func=group_show, endpoint='group_pages_index')
 pages.add_url_rule("/group/pages/<id>/<page>", view_func=group_show, endpoint='group_pages_show')
 pages.add_url_rule("/group/pages_edit/<id>", view_func=group_edit, endpoint='group_pages_new', methods=['GET', 'POST'])
 pages.add_url_rule("/group/pages_edit/<id>/", view_func=group_edit, endpoint='group_pages_new', methods=['GET', 'POST'])
-pages.add_url_rule("/group/pages_edit/<id>/<page>", view_func=group_edit, endpoint='group_pages_edit', methods=['GET', 'POST'])
-pages.add_url_rule("/group/pages_delete/<id>/<page>", view_func=group_delete, endpoint='group_pages_delete', methods=['GET', 'POST'])
+pages.add_url_rule("/group/pages_edit/<id>/<page>", view_func=group_edit,
+                   endpoint='group_pages_edit', methods=['GET', 'POST'])
+pages.add_url_rule("/group/pages_delete/<id>/<page>", view_func=group_delete,
+                   endpoint='group_pages_delete', methods=['GET', 'POST'])

--- a/ckanext/pages/cli.py
+++ b/ckanext/pages/cli.py
@@ -2,16 +2,24 @@ import click
 
 import ckanext.pages.utils as utils
 
+
 def get_commands():
     return [pages]
+
 
 @click.group()
 def pages():
     pass
 
+
 @pages.command()
 def initdb():
-    """Creates the necessary tables in the database.
+    """Adds simple pages to ckan
+
+    Usage:
+
+        pages initdb
+        - Creates the necessary tables in the database
     """
     utils.initdb()
     click.secho(u"DB tables created", fg=u"green")

--- a/ckanext/pages/cli.py
+++ b/ckanext/pages/cli.py
@@ -1,0 +1,17 @@
+import click
+
+import ckanext.pages.utils as utils
+
+def get_commands():
+    return [pages]
+
+@click.group()
+def pages():
+    pass
+
+@pages.command()
+def initdb():
+    """Creates the necessary tables in the database.
+    """
+    utils.initdb()
+    click.secho(u"DB tables created", fg=u"green")

--- a/ckanext/pages/commands.py
+++ b/ckanext/pages/commands.py
@@ -1,16 +1,21 @@
 import sys
 
-
 from ckan.plugins.toolkit import CkanCommand
 import ckanext.pages.utils as utils
 
+
 class PagesCommand(CkanCommand):
-    """
+    """Adds simple pages to ckan
+
+    Usage:
+
+        pages initdb
+        - Creates the necessary tables in the database
     """
     summary = __doc__.split('\n')[0]
     usage = __doc__
     max_args = 1
-    min_args = 1
+    min_args = 0
 
     def __init__(self, name):
         super(PagesCommand, self).__init__(name)
@@ -30,3 +35,4 @@ class PagesCommand(CkanCommand):
 
     def initdb(self):
         utils.initdb()
+        print("DB tables created")

--- a/ckanext/pages/commands.py
+++ b/ckanext/pages/commands.py
@@ -1,0 +1,32 @@
+import sys
+
+
+from ckan.plugins.toolkit import CkanCommand
+import ckanext.pages.utils as utils
+
+class PagesCommand(CkanCommand):
+    """
+    """
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+    max_args = 1
+    min_args = 1
+
+    def __init__(self, name):
+        super(PagesCommand, self).__init__(name)
+
+    def command(self):
+        self._load_config()
+
+        if len(self.args) == 0:
+            self.parser.print_usage()
+            sys.exit(1)
+        cmd = self.args[0]
+
+        if cmd == "initdb":
+            self.initdb()
+        else:
+            print("Command {0} not recognized".format(cmd))
+
+    def initdb(self):
+        utils.initdb()

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -22,6 +22,9 @@ def init_db():
     if pages_table is None:
         define_tables()
 
+    if not pages_table.exists():
+        pages_table.create()
+
 
 class Page(DomainObject):
 

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -14,6 +14,7 @@ from ckan.model.domain_object import DomainObject
 
 pages_table = None
 
+
 def make_uuid():
     return text_type(uuid.uuid4())
 
@@ -45,7 +46,7 @@ class Page(DomainObject):
         if order:
             query = query.order_by(sa.cast(cls.order, sa.Integer)).filter(cls.order != '')
         elif order_publish_date:
-            query = query.order_by(cls.publish_date.desc()).filter(cls.publish_date != None)
+            query = query.order_by(cls.publish_date.desc()).filter(cls.publish_date != None)  # noqa: E711
         else:
             query = query.order_by(cls.created.desc())
         return query.all()
@@ -61,7 +62,7 @@ def define_tables():
                            sa.Column('content', types.UnicodeText, default=u''),
                            sa.Column('lang', types.UnicodeText, default=u''),
                            sa.Column('order', types.UnicodeText, default=u''),
-                           sa.Column('private',types.Boolean,default=True),
+                           sa.Column('private', types.Boolean, default=True),
                            sa.Column('group_id', types.UnicodeText, default=None),
                            sa.Column('user_id', types.UnicodeText, default=u''),
                            sa.Column('publish_date', types.DateTime),
@@ -76,6 +77,7 @@ def define_tables():
         Page,
         pages_table,
     )
+
 
 def table_dictize(obj, context, **kw):
     '''Get any model object and represent it as a dict'''

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -18,57 +18,7 @@ def make_uuid():
     return text_type(uuid.uuid4())
 
 
-def init_db(model):
-
-    # We will just try to create the table.  If it already exists we get an
-    # error but we can just skip it and carry on.
-    sql = '''
-                CREATE TABLE ckanext_pages (
-                    id text NOT NULL,
-                    title text,
-                    name text,
-                    content text,
-                    lang text,
-                    "order" text,
-                    private boolean,
-                    group_id text,
-                    user_id text NOT NULL,
-                    created timestamp without time zone,
-                    modified timestamp without time zone
-                );
-    '''
-    conn = model.Session.connection()
-    try:
-        conn.execute(sql)
-    except sa.exc.ProgrammingError:
-        pass
-    model.Session.commit()
-
-    sql_upgrade_01 = (
-        "ALTER TABLE ckanext_pages add column publish_date timestamp;",
-        "ALTER TABLE ckanext_pages add column page_type Text;",
-        "UPDATE ckanext_pages set page_type = 'page';",
-    )
-
-    conn = model.Session.connection()
-    try:
-        for statement in sql_upgrade_01:
-            conn.execute(statement)
-    except sa.exc.ProgrammingError:
-        pass
-    model.Session.commit()
-
-    sql_upgrade_02 = ('ALTER TABLE ckanext_pages add column extras Text;',
-                      "UPDATE ckanext_pages set extras = '{}';")
-
-    conn = model.Session.connection()
-    try:
-        for statement in sql_upgrade_02:
-            conn.execute(statement)
-    except sa.exc.ProgrammingError:
-        pass
-    model.Session.commit()
-
+def init_db():
     if pages_table is None:
         define_tables()
 
@@ -112,7 +62,7 @@ def define_tables():
                            sa.Column('group_id', types.UnicodeText, default=None),
                            sa.Column('user_id', types.UnicodeText, default=u''),
                            sa.Column('publish_date', types.DateTime),
-                           sa.Column('page_type', types.DateTime),
+                           sa.Column('page_type', types.UnicodeText),
                            sa.Column('created', types.DateTime, default=datetime.datetime.utcnow),
                            sa.Column('modified', types.DateTime, default=datetime.datetime.utcnow),
                            sa.Column('extras', types.UnicodeText, default=u'{}'),

--- a/ckanext/pages/plugin/__init__.py
+++ b/ckanext/pages/plugin/__init__.py
@@ -201,6 +201,7 @@ class PagesPlugin(PagesPluginBase, MixinPlugin):
     def configure(self, config):
         db.init_db()
 
+
 class TextBoxView(p.SingletonPlugin):
 
     p.implements(p.IConfigurer, inherit=True)

--- a/ckanext/pages/plugin/__init__.py
+++ b/ckanext/pages/plugin/__init__.py
@@ -12,7 +12,7 @@ import ckantoolkit as tk
 import ckan.plugins as p
 from ckan.lib.helpers import build_nav_main as core_build_nav_main
 
-from ckanext.pages import actions
+from ckanext.pages import actions, db
 from ckanext.pages import auth
 
 if tk.check_ckan_version(min_version='2.5'):
@@ -128,6 +128,7 @@ class PagesPlugin(PagesPluginBase, MixinPlugin):
     p.implements(p.ITemplateHelpers, inherit=True)
     p.implements(p.IActions, inherit=True)
     p.implements(p.IAuthFunctions, inherit=True)
+    p.implements(p.IConfigurable, inherit=True)
 
     def update_config(self, config):
         self.organization_pages = tk.asbool(config.get('ckanext.pages.organization', False))
@@ -197,6 +198,8 @@ class PagesPlugin(PagesPluginBase, MixinPlugin):
             'ckanext_group_pages_list': auth.group_pages_list,
         }
 
+    def configure(self, config):
+        db.init_db()
 
 class TextBoxView(p.SingletonPlugin):
 

--- a/ckanext/pages/plugin/flask_plugin.py
+++ b/ckanext/pages/plugin/flask_plugin.py
@@ -3,11 +3,15 @@
 import ckan.plugins as p
 
 from ckanext.pages.blueprint import pages as pages_blueprint
-
+import ckanext.pages.cli as cli
 
 class MixinPlugin(p.SingletonPlugin):
 
     p.implements(p.IBlueprint)
+    p.implements(p.IClick)
 
     def get_blueprint(self):
         return [pages_blueprint]
+
+    def get_commands(self):
+        return cli.get_commands()

--- a/ckanext/pages/plugin/flask_plugin.py
+++ b/ckanext/pages/plugin/flask_plugin.py
@@ -5,6 +5,7 @@ import ckan.plugins as p
 from ckanext.pages.blueprint import pages as pages_blueprint
 import ckanext.pages.cli as cli
 
+
 class MixinPlugin(p.SingletonPlugin):
 
     p.implements(p.IBlueprint)

--- a/ckanext/pages/plugin/pylons_plugin.py
+++ b/ckanext/pages/plugin/pylons_plugin.py
@@ -16,9 +16,11 @@ class MixinPlugin(p.SingletonPlugin):
             map.connect('organization_pages_edit', '/organization/pages_edit/{id}{page:/.*|}',
                         action='org_edit', ckan_icon='edit', controller=controller)
             map.connect('organization_pages_index', '/organization/pages/{id}',
-                        action='org_show', ckan_icon='file', controller=controller, highlight_actions='org_edit org_show', page='')
+                        action='org_show', ckan_icon='file', controller=controller,
+                        highlight_actions='org_edit org_show', page='')
             map.connect('organization_pages', '/organization/pages/{id}{page:/.*|}',
-                        action='org_show', ckan_icon='file', controller=controller, highlight_actions='org_edit org_show')
+                        action='org_show', ckan_icon='file', controller=controller,
+                        highlight_actions='org_edit org_show')
 
         if self.group_pages:
             map.connect('group_pages_delete', '/group/pages_delete/{id}{page:/.*|}',
@@ -26,19 +28,22 @@ class MixinPlugin(p.SingletonPlugin):
             map.connect('group_pages_edit', '/group/pages_edit/{id}{page:/.*|}',
                         action='group_edit', ckan_icon='edit', controller=controller)
             map.connect('group_pages_index', '/group/pages/{id}',
-                        action='group_show', ckan_icon='file', controller=controller, highlight_actions='group_edit group_show', page='')
+                        action='group_show', ckan_icon='file', controller=controller,
+                        highlight_actions='group_edit group_show', page='')
             map.connect('group_pages', '/group/pages/{id}{page:/.*|}',
-                        action='group_show', ckan_icon='file', controller=controller, highlight_actions='group_edit group_show')
-
+                        action='group_show', ckan_icon='file', controller=controller,
+                        highlight_actions='group_edit group_show')
 
         map.connect('pages_delete', '/pages_delete{page:/.*|}',
                     action='pages_delete', ckan_icon='delete', controller=controller)
         map.connect('pages_edit', '/pages_edit{page:/.*|}',
                     action='pages_edit', ckan_icon='edit', controller=controller)
         map.connect('pages_index', '/pages',
-                    action='pages_index', ckan_icon='file', controller=controller, highlight_actions='pages_edit pages_index pages_show')
+                    action='pages_index', ckan_icon='file', controller=controller,
+                    highlight_actions='pages_edit pages_index pages_show')
         map.connect('pages_show', '/pages{page:/.*|}',
-                    action='pages_show', ckan_icon='file', controller=controller, highlight_actions='pages_edit pages_index pages_show')
+                    action='pages_show', ckan_icon='file', controller=controller,
+                    highlight_actions='pages_edit pages_index pages_show')
         map.connect('pages_upload', '/pages_upload',
                     action='pages_upload', controller=controller)
 
@@ -47,9 +52,9 @@ class MixinPlugin(p.SingletonPlugin):
         map.connect('blog_edit', '/blog_edit{page:/.*|}',
                     action='blog_edit', ckan_icon='edit', controller=controller)
         map.connect('blog_index', '/blog',
-                    action='blog_index', ckan_icon='file', controller=controller, highlight_actions='blog_edit blog_index blog_show')
+                    action='blog_index', ckan_icon='file', controller=controller,
+                    highlight_actions='blog_edit blog_index blog_show')
         map.connect('blog_show', '/blog{page:/.*|}',
-                    action='blog_show', ckan_icon='file', controller=controller, highlight_actions='blog_edit blog_index blog_show')
+                    action='blog_show', ckan_icon='file', controller=controller,
+                    highlight_actions='blog_edit blog_index blog_show')
         return map
-
-

--- a/ckanext/pages/tests/fixtures.py
+++ b/ckanext/pages/tests/fixtures.py
@@ -8,7 +8,7 @@ from ckanext.pages import db
 @pytest.fixture
 def pages_setup():
     if db.pages_table is None:
-        db.init_db(model)
+        db.init_db()
 
 
 @pytest.fixture

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -11,7 +11,7 @@ from ckanext.pages.logic import schema
 ckan_29_or_higher = toolkit.check_ckan_version(u'2.9')
 
 
-@pytest.mark.usefixtures("clean_db", "clean_pages", "pages_setup")
+@pytest.mark.usefixtures("clean_db", "pages_setup")
 class TestPages():
 
     def test_create_page(self, app):

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -407,5 +407,4 @@ def group_delete(id, group_type, page):
 
 def initdb():
     import ckanext.pages.db as db
-    from ckan import model
-    db.init_db(model)
+    db.init_db()

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -404,3 +404,9 @@ def group_delete(id, group_type, page):
         'ckanext_pages/confirm_delete.html',
         {'page': page, 'group_type': group_type, 'group_dict': group_dict}
     )
+
+def initdb():
+    import ckanext.pages.db as db
+    from ckan import model
+    if db.pages_table is None:
+        db.init_db(model)

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -143,7 +143,8 @@ def _inject_views_into_page(_page):
             if not height.endswith('%') and not height.endswith('px'):
                 height = height + 'px'
             align = element.attrib.pop('align', 'none')
-            style = "width: %s; height: %s; float: %s; overflow: auto; vertical-align:middle; position:relative" % (width, height, align)
+            style = "width: %s; height: %s; float: %s; overflow: auto; vertical-align:middle; position:relative" \
+                    % (width, height, align)
             element.attrib['style'] = style
             element.attrib['class'] = 'pages-embed'
             view = tk.get_action('resource_view_show')({}, {'id': iframe_src[-36:]})
@@ -160,11 +161,15 @@ def _inject_views_into_page(_page):
             resource_view_html = helpers.rendered_resource_view(view, resource, package)
         else:
             if ckan_29_or_higher:
-                src = helpers.url_for('resource.view', id=package['name'], resource_id=resource['id'], view_id=view['id'], _external=True)
+                src = helpers.url_for('resource.view', id=package['name'],
+                                      resource_id=resource['id'], view_id=view['id'], _external=True)
             else:
-                src = helpers.url_for(qualified=True, controller='package', action='resource_view', id=package['name'], resource_id=resource['id'], view_id=view['id'])
+                src = helpers.url_for(qualified=True, controller='package',
+                                      action='resource_view', id=package['name'],
+                                      resource_id=resource['id'], view_id=view['id'])
             message = _('Your browser does not support iframes.')
-            resource_view_html = '<iframe src="{src}" frameborder="0" width="100%" height="100%" style="display:block"> <p>{message}</p> </iframe>'.format(src=src, message=message)
+            resource_view_html = '<iframe src="{src}" frameborder="0" width="100%" height="100%" ' \
+                                 'style="display:block"> <p>{message}</p> </iframe>'.format(src=src, message=message)
 
         view_element = lxml.html.fromstring(resource_view_html)
         element.append(view_element)
@@ -246,7 +251,6 @@ def pages_upload():
         return upload_info
     else:
         return json.dumps(upload_info)
-
 
 
 def group_list_pages(id, group_type, group_dict=None):
@@ -404,6 +408,7 @@ def group_delete(id, group_type, page):
         'ckanext_pages/confirm_delete.html',
         {'page': page, 'group_type': group_type, 'group_dict': group_dict}
     )
+
 
 def initdb():
     import ckanext.pages.db as db

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -408,5 +408,4 @@ def group_delete(id, group_type, page):
 def initdb():
     import ckanext.pages.db as db
     from ckan import model
-    if db.pages_table is None:
-        db.init_db(model)
+    db.init_db(model)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         textboxview=ckanext.pages.plugin:TextBoxView
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
+        [paste.paster_command]
+        pages = ckanext.pages.commands:PagesCommand
     """,
     message_extractors={
         'ckanext': [


### PR DESCRIPTION
Fixes #106

Database initialization code is executed on all actions and auth functions which probably leads to errors on multi-thread environments. This PR moves the initialization code to cli and is more inline with the other extensions and good conventions. Database initialization is also somewhat cleaned as raw sql lines were removed as sqlalchemy mapper already existed.

Also flake8 violations are fixed.