### PR TITLE
Fix and clean several bugs

### DIFF
--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -1,10 +1,8 @@
-import ckantoolkit
-
 import ckan.plugins as p
 
 import ckanext.pages.utils as utils
 
-config = ckantoolkit.config
+config = p.toolkit.config
 
 _ = p.toolkit._
 

--- a/ckanext/pages/plugin/__init__.py
+++ b/ckanext/pages/plugin/__init__.py
@@ -7,9 +7,9 @@ except ImportError:
 import six
 from six.moves.urllib.parse import quote
 
-import ckantoolkit as tk
-
 import ckan.plugins as p
+import ckan.plugins.toolkit as tk
+
 from ckan.lib.helpers import build_nav_main as core_build_nav_main
 
 from ckanext.pages import actions, db

--- a/ckanext/pages/tests/test_action.py
+++ b/ckanext/pages/tests/test_action.py
@@ -56,7 +56,6 @@ class TestPagesActions():
         assert page['title'] == 'New Page Updated'
         assert page['content'] == 'This is a test content updated'
 
-
     def test_pages_list(self, app):
         sysadmin = factories.Sysadmin()
         helpers.call_action(

--- a/ckanext/pages/tests/test_action.py
+++ b/ckanext/pages/tests/test_action.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ckan.plugins import toolkit
+from ckan.tests import factories, helpers
+
+@pytest.mark.usefixtures("clean_db", "pages_setup")
+class TestPagesActions():
+
+    def test_pages_create_action(self, app):
+        user = factories.User()
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': user['name']},
+            name='page_name', title='New Page', content='This is a test content'
+        )
+
+        page = helpers.call_action(
+            'ckanext_pages_show',
+            {},
+            page='page_name')
+
+        assert page['name'] == 'page_name'
+        assert page['title'] == 'New Page'
+        assert page['content'] == 'This is a test content'
+
+    def test_pages_update_action(self, app):
+        user = factories.User()
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': user['name']},
+            name='page_name', title='New Page', content='This is a test content'
+        )
+
+        page = helpers.call_action(
+            'ckanext_pages_show',
+            {},
+            page='page_name')
+
+        assert page['name'] == 'page_name'
+        assert page['title'] == 'New Page'
+        assert page['content'] == 'This is a test content'
+
+        # sending the parameter page is mandatory for the validator to pass.
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': user['name']},
+            name='page_name', title='New Page Updated', content='This is a test content updated', page='page_name'
+        )
+
+        page = helpers.call_action(
+            'ckanext_pages_show',
+            {},
+            page='page_name')
+
+        assert page['name'] == 'page_name'
+        assert page['title'] == 'New Page Updated'
+        assert page['content'] == 'This is a test content updated'

--- a/ckanext/pages/tests/test_action.py
+++ b/ckanext/pages/tests/test_action.py
@@ -2,6 +2,7 @@ import pytest
 
 from ckan.tests import factories, helpers
 
+
 @pytest.mark.usefixtures("clean_db", "pages_setup")
 class TestPagesActions():
 

--- a/ckanext/pages/tests/test_action.py
+++ b/ckanext/pages/tests/test_action.py
@@ -55,3 +55,50 @@ class TestPagesActions():
         assert page['name'] == 'page_name'
         assert page['title'] == 'New Page Updated'
         assert page['content'] == 'This is a test content updated'
+
+
+    def test_pages_list(self, app):
+        sysadmin = factories.Sysadmin()
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': sysadmin['name']},
+            name='page_name_1', title='New Page 1', content='This is a test content', private=False
+        )
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': sysadmin['name']},
+            name='page_name_2', title='New Page 2', content='This is a test content', private=False
+        )
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': sysadmin['name']},
+            name='page_name_3', title='New Page 3', content='This is a test content', private=False
+        )
+
+        results = helpers.call_action(
+            'ckanext_pages_list',
+            {'user': sysadmin['name']}
+            )
+
+        assert len(results) == 3
+        assert results[0]['title'] == 'New Page 3'
+        assert results[2]['title'] == 'New Page 1'
+
+        helpers.call_action(
+            'ckanext_pages_update',
+            {'user': sysadmin['name']},
+            name='page_name_4', title='New Page 4', content='This is a test content', private=True
+        )
+
+        results = helpers.call_action(
+            'ckanext_pages_list',
+            {'user': sysadmin['name']}
+            )
+        assert len(results) == 4
+
+        user = factories.User()
+        results = helpers.call_action(
+            'ckanext_pages_list',
+            {'user': user['name'], 'ignore_auth': False}
+            )
+        assert len(results) == 3

--- a/ckanext/pages/tests/test_action.py
+++ b/ckanext/pages/tests/test_action.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
 
 @pytest.mark.usefixtures("clean_db", "pages_setup")

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -36,6 +36,40 @@ class TestPages():
 
         assert '<h1 class="page-heading">Page Title</h1>' in response.body
 
+    def test_cannot_create_page_with_same_name(self, app):
+        user = factories.Sysadmin()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        page = 'test_page'
+        page = '/' + page if not ckan_29_or_higher else page
+        response = app.post(
+            url=toolkit.url_for('pages.new', page=page),
+            params={
+                'title': 'Page Title',
+                'name': 'page_name',
+                'private': False,
+            },
+            extra_environ=env,
+        )
+        if not ckan_29_or_higher:
+            response = response.follow(extra_environ=env)
+
+        assert '<h1 class="page-heading">Page Title</h1>' in response.body
+
+        response = app.post(
+            url=toolkit.url_for('pages.new', page=page),
+            params={
+                'title': 'Page Title',
+                'name': 'page_name',
+                'private': False,
+            },
+            extra_environ=env,
+        )
+        if not ckan_29_or_higher:
+            response = response.follow(extra_environ=env)
+
+        assert '<div class="flash-messages">' in response.body
+        assert 'Page name already exists' in response.body
+
     @pytest.mark.ckan_config('ckanext.pages.allow_html', 'True')
     def test_rendering_with_html_allowed(self, app):
         user = factories.Sysadmin()

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -7,7 +7,7 @@ except ImportError:
 import pytest
 
 from ckan.plugins import toolkit
-from ckantoolkit.tests import factories, helpers
+from ckan.tests import factories, helpers
 
 from ckanext.pages.logic import schema
 

--- a/ckanext/pages/textbox/templates/textbox_form.html
+++ b/ckanext/pages/textbox/templates/textbox_form.html
@@ -1,6 +1,6 @@
    <div class="control-group">
       <label for="field-content-ck" class="control-label">{{ _('Content') }}</label>
    </div>
-   <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="textbox" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
+   <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="textbox" style="height:400px" data-module-site_url="{{ h.dump_json(h.url_for('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
 
    {% resource 'textbox/main' %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -137,7 +137,7 @@
       <div class="control-group">
           <label for="field-content-ck" class="control-label">{{ _('Content') }}</label>
       </div>
-      <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
+      <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url_for('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
     {% else %}
       {{ form.markdown('content', id='field-content', label=_('Content'), placeholder=_('Enter content here'), value=data.content, error=errors.content) }}
     {% endif %}

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -1,9 +1,9 @@
 import six
 import json
 
-import ckantoolkit as tk
 import ckan.lib.navl.dictization_functions as dict_fns
 import ckan.plugins as p
+import ckan.plugins.toolkit as tk
 import ckan.logic as logic
 import ckan.lib.helpers as helpers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ckantoolkit
 six

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        'six', 'ckantoolkit',
+        'six',
     ],
     entry_points="""
         [ckan.plugins]


### PR DESCRIPTION
This PR cleans some code, fixes a few bugs and adds some more test coverage:

## Fixes
 - Helper `url` has been deprecated in CKAN 2.10. Using `url_for` instead.
 - Do no depend on `ckantoolkit` and use `ckan.plugins.toolkit` instead