### PR TITLE
Replace deprecated h.url() helper.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.10'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/ckanext/pages/textbox/templates/textbox_form.html
+++ b/ckanext/pages/textbox/templates/textbox_form.html
@@ -1,6 +1,6 @@
    <div class="control-group">
       <label for="field-content-ck" class="control-label">{{ _('Content') }}</label>
    </div>
-   <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="textbox" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
+   <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="textbox" style="height:400px" data-module-site_url="{{ h.dump_json(h.url_for('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
 
    {% resource 'textbox/main' %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -137,7 +137,7 @@
       <div class="control-group">
           <label for="field-content-ck" class="control-label">{{ _('Content') }}</label>
       </div>
-      <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
+      <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url_for('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
     {% else %}
       {{ form.markdown('content', id='field-content', label=_('Content'), placeholder=_('Enter content here'), value=data.content, error=errors.content) }}
     {% endif %}


### PR DESCRIPTION
Helper `h.url(...)` has been deprecated in favor of `h.url_for(...)`.

Current codebase will throw an error when running it in CKAN 2.10.