### PR TITLE
fix: wrong endpoint name for redirect after page removal

### DIFF
--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -196,7 +196,7 @@ def pages_delete(page, page_type='pages'):
     try:
         if tk.request.method == 'POST':
             tk.get_action('ckanext_pages_delete')({}, {'page': page})
-            endpoint = 'index' if page_type in ('pages', 'page') else '%s_index' % page_type
+            endpoint = page_type + '_index'
             return tk.redirect_to('pages.%s' % endpoint)
         else:
             return tk.abort(404, _('Page Not Found'))


### PR DESCRIPTION
Problem: When the page is successfully deleted, a user is redirected to the `pages.index` endpoint, which was renamed recently to `pages.pages_index`

Fix: Update redirect and use the current name of the endpoint.