### PR TITLE
fix2.11 main menu org grp options

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -29,9 +29,9 @@ def build_pages_nav_main(*args):
     for arg in args:
         if arg[0] in 'home.about' and not about_menu:
             continue
-        if arg[0] in 'home.group_index' and not org_menu:
+        if arg[0] in 'group.index' and not group_menu:
             continue
-        if arg[0] in 'home.organizations_index' and not group_menu:
+        if arg[0] in 'organization.index' and not org_menu:
             continue
         new_args.append(arg)
 


### PR DESCRIPTION
This fixes  [issue 134 ](https://github.com/ckan/ckanext-pages/issues/134)- restoring function to the options that hide the groups and organizations on the main menu in ckan 2.11.  

```
ckanext.pages.group_menu = False
ckanext.pages.organization_menu = False
```

..still finding my way with github and PR