### PR TITLE
Pages revisions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ ckanext.pages.revisions_limit = 3
 
 By default the value is set to `3` revisions to be stored. While adding this option with a higher number, the amount of stored revisions will be increased.
 
+```
+ckanext.pages.revisions_force_limit = true
+```
+
+By default is set to `False`. Needed when the `ckanext.pages.revisions_limit` number is decresed from the original (e.g. from 5 to 2) and we want to make sure that all Pages after update will have only specified number of Revisions instead of the old setting number. Without it, if Page had previously 5 Revisions, the page will continue to have 5 Revisions as it removes only the last one, so the new number limit will effect only new Pages, while setting this option to `true`, will force old Pages after update to have the spcific amount of last Revisions.
+
 ## Extending ckanext-pages schema
 
 This extension defines an `IPagesSchema` interface that allows other extensions to update the pages schema and add custom fields.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ ckanext.pages.editor = ckeditor
 ```
 This enables either the [medium](https://jakiestfu.github.io/Medium.js/docs/) or [ckeditor](http://ckeditor.com/)
 
+```
+ckanext.pages.revisions_limit = 3
+```
+
+By default the value is set to `3` revisions to be stored. While adding this option with a higher number, the amount of stored revisions will be increased.
+
 ## Extending ckanext-pages schema
 
 This extension defines an `IPagesSchema` interface that allows other extensions to update the pages schema and add custom fields.

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -141,7 +141,7 @@ def _pages_update(context, data_dict):
     revisions = out.revisions
 
     new_revision = {
-        make_uuid() : {
+        make_uuid(): {
             "content": out.content,
             "user_id": user.id,
             "created": datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -172,28 +172,10 @@ def _pages_update(context, data_dict):
     session.commit()
 
 
-def _pages_revision_restore(context, data_dict):
-    name = data_dict.get('page')
-    rev = data_dict.get('revision')
-    page = db.Page.get(name=name)
-
-    if page and page.revisions:
-        page.revisions = _remove_keys_revision_from_dict(page.revisions)
-        revision = page.revisions.get(rev)
-
-        try:
-            revision['current'] = True
-            page.content = revision['content']
-            page.save()
-            return revision
-        except TypeError:
-            raise TypeError("Unexpected value.")
-
-
 def _remove_keys_revision_from_dict(data_dict, keys=['current']):
     return {
-        id:{
-            key:data_dict[id][key] for key in data_dict[id] if key not in keys
+        id: {
+            key: data_dict[id][key] for key in data_dict[id] if key not in keys
             } for id in data_dict
     }
 
@@ -256,7 +238,21 @@ def pages_update(context, data_dict):
 
 def pages_revision_restore(context, data_dict):
     p.toolkit.check_access('ckanext_pages_update', context, data_dict)
-    return _pages_revision_restore(context, data_dict)
+    name = data_dict.get('page')
+    rev = data_dict.get('revision')
+    page = db.Page.get(name=name)
+
+    if page and page.revisions:
+        page.revisions = _remove_keys_revision_from_dict(page.revisions)
+        revision = page.revisions.get(rev)
+
+        try:
+            revision['current'] = True
+            page.content = revision['content']
+            page.save()
+            return revision
+        except TypeError:
+            raise TypeError("Unexpected value.")
 
 
 def pages_delete(context, data_dict):

--- a/ckanext/pages/blueprint.py
+++ b/ckanext/pages/blueprint.py
@@ -13,6 +13,18 @@ def show(page):
     return utils.pages_show(page, page_type='page')
 
 
+def pages_revisions(page):
+    return utils.pages_revisions(page, page_type='page')
+
+
+def pages_revisions_preview(page, revision):
+    return utils.pages_revisions_preview(page, revision, page_type='page')
+
+
+def pages_revision_restore(page, revision):
+    return utils.pages_revision_restore(page, revision, page_type='page')
+
+
 def pages_edit(page=None, data=None, errors=None, error_summary=None):
     return utils.pages_edit(page, data, errors, error_summary, 'page')
 
@@ -35,6 +47,18 @@ def blog_show(page):
 
 def blog_edit(page=None, data=None, errors=None, error_summary=None):
     return utils.pages_edit(page, data, errors, error_summary, 'blog')
+
+
+def blog_revisions(page):
+    return utils.pages_revisions(page, page_type='blog')
+
+
+def blog_revisions_preview(page, revision):
+    return utils.pages_revisions_preview(page, revision, page_type='blog')
+
+
+def blog_revision_restore(page, revision):
+    return utils.pages_revision_restore(page, revision, page_type='blog')
 
 
 def blog_delete(page):
@@ -67,6 +91,9 @@ def group_edit(id, page=None, data=None, errors=None, error_summary=None):
 
 pages.add_url_rule("/pages", view_func=index, endpoint="pages_index")
 pages.add_url_rule("/pages/<page>", view_func=show)
+pages.add_url_rule("/pages/<page>/revisions", view_func=pages_revisions)
+pages.add_url_rule("/pages/<page>/revisions/<revision>", view_func=pages_revisions_preview)
+pages.add_url_rule("/pages/<page>/revisions/<revision>/restore", view_func=pages_revision_restore, methods=['GET'])
 pages.add_url_rule("/pages_edit", view_func=pages_edit, endpoint='new', methods=['GET', 'POST'])
 pages.add_url_rule("/pages_edit/", view_func=pages_edit, endpoint='new', methods=['GET', 'POST'])
 pages.add_url_rule("/pages_edit/<page>", view_func=pages_edit, endpoint='edit', methods=['GET', 'POST'])
@@ -77,6 +104,9 @@ pages.add_url_rule("/pages_upload", view_func=upload, methods=['POST'])
 
 pages.add_url_rule("/blog", view_func=blog_index)
 pages.add_url_rule("/blog/<page>", view_func=blog_show)
+pages.add_url_rule("/blog/<page>/revisions", view_func=blog_revisions)
+pages.add_url_rule("/blog/<page>/revisions/<revision>", view_func=blog_revisions_preview)
+pages.add_url_rule("/blog/<page>/revisions/<revision>/restore", view_func=blog_revision_restore, methods=['GET'])
 pages.add_url_rule("/blog_edit", view_func=blog_edit, endpoint='blog_new', methods=['GET', 'POST'])
 pages.add_url_rule("/blog_edit/", view_func=blog_edit, endpoint='blog_new', methods=['GET', 'POST'])
 pages.add_url_rule("/blog_edit/<page>", view_func=blog_edit, endpoint='blog_edit', methods=['GET', 'POST'])

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -80,9 +80,12 @@ class Page(DomainObject, BaseModel):
         return query.all()
 
     def get_ordered_revisions(self):
+        # Compare timestamps to avoid different datetime formats error
         return OrderedDict(reversed(sorted(
                 self.revisions.items(),
-                key=lambda x: datetime.datetime.fromisoformat(x[1]['created'])
+                key=lambda x: datetime.datetime.timestamp(
+                    datetime.datetime.fromisoformat(x[1]['created'])
+                    )
         )))
 
 

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -2,10 +2,13 @@ import datetime
 import uuid
 import json
 
+from collections import OrderedDict
 from six import text_type
 import sqlalchemy as sa
 from sqlalchemy import Column, types
 from sqlalchemy.orm import class_mapper
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.dialects.postgresql import JSONB
 
 try:
     from sqlalchemy.engine import Row
@@ -52,6 +55,7 @@ class Page(DomainObject, BaseModel):
     created = Column(types.DateTime, default=datetime.datetime.utcnow)
     modified = Column(types.DateTime, default=datetime.datetime.utcnow)
     extras = Column(types.UnicodeText, default=u'{}')
+    revisions = Column(MutableDict.as_mutable(JSONB), default=u'{}')
 
     @classmethod
     def get(cls, **kw):
@@ -74,6 +78,12 @@ class Page(DomainObject, BaseModel):
         else:
             query = query.order_by(cls.created.desc())
         return query.all()
+
+    def get_ordered_revisions(self):
+        return OrderedDict(reversed(sorted(
+                self.revisions.items(),
+                key=lambda x: datetime.datetime.fromisoformat(x[1]['created'])
+        )))
 
 
 def table_dictize(obj, context, **kw):

--- a/ckanext/pages/migration/pages/versions/1725892d1d94_create_revisions_table.py
+++ b/ckanext/pages/migration/pages/versions/1725892d1d94_create_revisions_table.py
@@ -1,0 +1,31 @@
+"""Create revisions column
+
+Revision ID: 1725892d1d94
+Revises: a756dbd73ead
+Create Date: 2024-10-13 12:09:25.372524
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '1725892d1d94'
+down_revision = 'a756dbd73ead'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        u'ckanext_pages',
+        sa.Column(
+            u'revisions',
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column(u'ckanext_pages', u'revisions')

--- a/ckanext/pages/migration/pages/versions/1725892d1d94_create_revisions_table.py
+++ b/ckanext/pages/migration/pages/versions/1725892d1d94_create_revisions_table.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        u'ckanext_pages',
+        'ckanext_pages',
         sa.Column(
             u'revisions',
             postgresql.JSONB(astext_type=sa.Text()),

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -128,6 +128,7 @@ class PagesPlugin(PagesPluginBase):
         actions_dict = {
             'ckanext_pages_show': actions.pages_show,
             'ckanext_pages_update': actions.pages_update,
+            'ckanext_pages_revision_restore': actions.pages_revision_restore,
             'ckanext_pages_delete': actions.pages_delete,
             'ckanext_pages_list': actions.pages_list,
             'ckanext_pages_upload': actions.pages_upload,

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog.html
@@ -4,26 +4,31 @@
 
 {% block primary_content %}
   <section class="module-content">
-    {% if h.check_access('ckanext_pages_update') %}
-      {% asset 'pages/main-css' %}
-      {% link_for _('Edit'), named_route='pages.blog_edit', page=c.page.name, class_='btn btn-primary pull-right', icon='plus-square' %}
-    {% endif %}
+    {% block ckanext_pages_actions %}
+      {% if h.check_access('ckanext_pages_update') %}
+        {% asset 'pages/main-css' %}
+        {% link_for _('Edit'), named_route='pages.blog_edit', page=c.page.name, class_='btn btn-primary pull-right', icon='plus-square' %}
+        {% link_for _('Revisions'), named_route='pages.blog_revisions', page=c.page.name, class_='btn btn-primary pull-right me-2', icon='eye' %}
+      {% endif %}
+    {% endblock %}
     <h1 class="page-heading">{{ c.page.title }}</h1>
       {% if c.page.publish_date %}
          <span class="muted date"> {{ h.render_datetime(c.page.publish_date) }} </span>
       {% endif %}
-    {% if c.page.content %}
-      {% set editor = h.pages_get_wysiwyg_editor() %}
-      {% if editor %}
-        <div>
-            {{c.page.content|safe}}
-        </div>
+    {% block ckanext_pages_content %}
+      {% if c.page.content %}
+        {% set editor = h.pages_get_wysiwyg_editor() %}
+        {% if editor %}
+          <div>
+              {{c.page.content|safe}}
+          </div>
+        {% else %}
+          {{ h.render_content(c.page.content) }}
+        {% endif %}
       {% else %}
-        {{ h.render_content(c.page.content) }}
+        <p class="empty">{{ _('This page currently has no content') }}</p>
       {% endif %}
-    {% else %}
-      <p class="empty">{{ _('This page currently has no content') }}</p>
-    {% endif %}
+    {% endblock %}
   </section>
 {% endblock %}
 

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
@@ -1,0 +1,49 @@
+{% extends 'page.html' %}
+
+{% macro actor(revision) %}
+  <span>
+    {{ h.linked_user(revision.user_id, 0, 30) }}
+  </span>
+{% endmacro %}
+
+{% block bodytag %}{{ super() }} class="blog"{% endblock %}
+{% block subtitle %}{{ c.page.title }}{% endblock %}
+
+{% block primary %}
+  <section class="module-content">
+    {% if h.check_access('ckanext_pages_update') %}
+      {% asset 'pages/main-css' %}
+      {% link_for _('View'), named_route='pages.blog_show', page=c.page.name, class_='btn btn-primary pull-right', icon='eye' %}
+    {% endif %}
+    <h1 class="page-heading">{{ c.page.title }}</h1>
+    {% if c.page.revisions %}
+      <div class="ckanext-pages-content">
+        <ul class="activity">
+            {% for key, revision in c.page.get_ordered_revisions().items() %}
+                <li class="item">
+                    <span class="fa-stack fa-lg">
+                    <i class="fa fa-circle fa-stack-2x icon"></i>
+                    <i class="fa fa-users fa-stack-1x fa-inverse"></i>
+                    </span>
+                    {{ _('{actor} updated page at {date}').format(
+                    actor=actor(revision), date=h.render_datetime(revision.created, with_hours=True)
+                    )|safe }}
+
+                    {% link_for _('Preview'), named_route='pages.blog_revisions_preview', page=c.page.name, revision=key, class_='' %}
+                    {% link_for _('Restore'), named_route='pages.blog_revision_restore', page=c.page.name, revision=key, class_='' %}                   
+                    <br />
+                    <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">
+                        {{ h.time_ago_from_timestamp(revision.created) }}
+                      </span>
+                    </span>
+                </li>
+            {% endfor %}
+        </ul>
+      </div>
+    {% else %}
+      <p class="empty">{{ _('This blog currently has no revisions') }}</p>
+    {% endif %}
+  </section>
+{% endblock %}
+
+{% block secondary %}{% endblock %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
@@ -30,7 +30,11 @@
                     )|safe }}
 
                     {% link_for _('Preview'), named_route='pages.blog_revisions_preview', page=c.page.name, revision=key, class_='' %}
-                    {% link_for _('Restore'), named_route='pages.blog_revision_restore', page=c.page.name, revision=key, class_='' %}                   
+                    {% if not revision.current %}
+                      {% link_for _('Restore'), named_route='pages.blog_revision_restore', page=c.page.name, revision=key, class_='' %}
+                    {% else %}
+                      <span>{{ _('Active Revision') }}</span>
+                    {% endif %}
                     <br />
                     <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">
                         {{ h.time_ago_from_timestamp(revision.created) }}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions.html
@@ -29,11 +29,11 @@
                     actor=actor(revision), date=h.render_datetime(revision.created, with_hours=True)
                     )|safe }}
 
-                    {% link_for _('Preview'), named_route='pages.blog_revisions_preview', page=c.page.name, revision=key, class_='' %}
+                    {% link_for _('Preview'), named_route='pages.blog_revisions_preview', page=c.page.name, revision=key, class_='btn btn-default' %}
                     {% if not revision.current %}
-                      {% link_for _('Restore'), named_route='pages.blog_revision_restore', page=c.page.name, revision=key, class_='' %}
+                      {% link_for _('Restore'), named_route='pages.blog_revision_restore', page=c.page.name, revision=key, class_='btn btn-primary' %}
                     {% else %}
-                      <span>{{ _('Active Revision') }}</span>
+                      <span class="badge badge-inverse">{{ _('Active Revision') }}</span>
                     {% endif %}
                     <br />
                     <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
@@ -16,7 +16,7 @@
                   {{revision.content|safe}}
               </div>
             {% else %}
-              {{ h.render_content(c.page.content) }}
+              {{ h.render_content(revision.content) }}
             {% endif %}
         </div>
     {% else %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
@@ -1,0 +1,17 @@
+{% extends 'ckanext_pages/blog.html' %}
+
+{% block ckanext_pages_actions %}
+    {% if h.check_access('ckanext_pages_update') %}
+        {% asset 'pages/main-css' %}
+        {% link_for _('Revisions'), named_route='pages.blog_revisions', page=c.page.name, class_='btn btn-primary pull-right', icon='eye' %}
+    {% endif %}
+{% endblock %}
+{% block ckanext_pages_content %}
+    {% if revision.content %}
+        <div class="ckanext-pages-content">
+            {{ h.render_content(revision.content) }}
+        </div>
+    {% else %}
+        <p class="empty">{{ _('This page currently has no content') }}</p>
+    {% endif %}
+{% endblock %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/blog_revisions_preview.html
@@ -9,7 +9,15 @@
 {% block ckanext_pages_content %}
     {% if revision.content %}
         <div class="ckanext-pages-content">
-            {{ h.render_content(revision.content) }}
+            {% set editor = h.pages_get_wysiwyg_editor() %}
+            <!-- editor set to "{{ editor }}"-->
+            {% if editor %}
+              <div>
+                  {{revision.content|safe}}
+              </div>
+            {% else %}
+              {{ h.render_content(c.page.content) }}
+            {% endif %}
         </div>
     {% else %}
         <p class="empty">{{ _('This page currently has no content') }}</p>

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page.html
@@ -9,6 +9,7 @@
       {% if h.check_access('ckanext_pages_update') %}
           {% asset 'pages/main-css' %}
           {% link_for _('Edit'), named_route='pages.edit', page=c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+          {% link_for _('Revisions'), named_route='pages.pages_revisions', page=c.page.name, class_='btn btn-primary pull-right me-2', icon='eye' %}
       {% endif %}
     {% endblock %}
     <h1 class="page-heading">{{ c.page.title }}</h1>

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
@@ -32,11 +32,11 @@
                         actor=actor(revision), date=h.render_datetime(revision.created, with_hours=True)
                         )|safe }}
 
-                        {% link_for _('Preview'), named_route='pages.pages_revisions_preview', page=c.page.name, revision=key, class_='' %}
+                        {% link_for _('Preview'), named_route='pages.pages_revisions_preview', page=c.page.name, revision=key, class_='btn btn-default' %}
                         {% if not revision.current %}
-                          {% link_for _('Restore'), named_route='pages.pages_revision_restore', page=c.page.name, revision=key, class_='' %}
+                          {% link_for _('Restore'), named_route='pages.pages_revision_restore', page=c.page.name, revision=key, class_='btn btn-primary' %}
                         {% else %}
-                          <span>{{ _('Active Revision') }}</span>
+                          <span class="badge badge-inverse">{{ _('Active Revision') }}</span>
                         {% endif %}
                         <br />
                         <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
@@ -33,7 +33,11 @@
                         )|safe }}
 
                         {% link_for _('Preview'), named_route='pages.pages_revisions_preview', page=c.page.name, revision=key, class_='' %}
-                        {% link_for _('Restore'), named_route='pages.pages_revision_restore', page=c.page.name, revision=key, class_='' %}                   
+                        {% if not revision.current %}
+                          {% link_for _('Restore'), named_route='pages.pages_revision_restore', page=c.page.name, revision=key, class_='' %}
+                        {% else %}
+                          <span>{{ _('Active Revision') }}</span>
+                        {% endif %}
                         <br />
                         <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">
                             {{ h.time_ago_from_timestamp(revision.created) }}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions.html
@@ -1,0 +1,54 @@
+{% extends 'page.html' %}
+
+{% macro actor(revision) %}
+  <span>
+    {{ h.linked_user(revision.user_id, 0, 30) }}
+  </span>
+{% endmacro %}
+
+{% block subtitle %}{{ c.page.title }}{% endblock %}
+
+{% block primary %}
+  <section class="module-content">
+
+    {% block ckanext_pages_actions %}
+      {% if h.check_access('ckanext_pages_update') %}
+          {% asset 'pages/main-css' %}
+          {% link_for _('View Page'), named_route='pages.show', page=c.page.name, class_='btn btn-primary pull-right', icon='eye' %}
+      {% endif %}
+    {% endblock %}
+    <h1 class="page-heading">{{ c.page.title }}</h1>
+      {% block ckanext_pages_content %}
+        {% if c.page.revisions %}
+          <div class="ckanext-pages-content">
+            <ul class="activity">
+                {% for key, revision in c.page.get_ordered_revisions().items() %}
+                    <li class="item">
+                        <span class="fa-stack fa-lg">
+                        <i class="fa fa-circle fa-stack-2x icon"></i>
+                        <i class="fa fa-users fa-stack-1x fa-inverse"></i>
+                        </span>
+                        {{ _('{actor} updated page at {date}').format(
+                        actor=actor(revision), date=h.render_datetime(revision.created, with_hours=True)
+                        )|safe }}
+
+                        {% link_for _('Preview'), named_route='pages.pages_revisions_preview', page=c.page.name, revision=key, class_='' %}
+                        {% link_for _('Restore'), named_route='pages.pages_revision_restore', page=c.page.name, revision=key, class_='' %}                   
+                        <br />
+                        <span class="date" title="{{ h.render_datetime(revision.created, with_hours=True) }}">
+                            {{ h.time_ago_from_timestamp(revision.created) }}
+                          </span>
+                        </span>
+                    </li>
+                {% endfor %}
+            </ul>
+          </div>
+        {% else %}
+          <p class="empty">{{ _('This page currently has no revisions') }}</p>
+        {% endif %}
+
+      {% endblock %}
+  </section>
+{% endblock %}
+
+{% block secondary %}{% endblock %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
@@ -16,7 +16,7 @@
                   {{revision.content|safe}}
               </div>
             {% else %}
-              {{ h.render_content(c.page.content) }}
+              {{ h.render_content(revision.content) }}
             {% endif %}
         </div>
     {% else %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
@@ -1,0 +1,17 @@
+{% extends 'ckanext_pages/page.html' %}
+
+{% block ckanext_pages_actions %}
+    {% if h.check_access('ckanext_pages_update') %}
+        {% asset 'pages/main-css' %}
+        {% link_for _('Revisions'), named_route='pages.pages_revisions', page=c.page.name, class_='btn btn-primary pull-right', icon='eye' %}
+    {% endif %}
+{% endblock %}
+{% block ckanext_pages_content %}
+    {% if revision.content %}
+        <div class="ckanext-pages-content">
+            {{ h.render_content(revision.content) }}
+        </div>
+    {% else %}
+        <p class="empty">{{ _('This page currently has no content') }}</p>
+    {% endif %}
+{% endblock %}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/page_revisions_preview.html
@@ -9,7 +9,15 @@
 {% block ckanext_pages_content %}
     {% if revision.content %}
         <div class="ckanext-pages-content">
-            {{ h.render_content(revision.content) }}
+            {% set editor = h.pages_get_wysiwyg_editor() %}
+            <!-- editor set to "{{ editor }}"-->
+            {% if editor %}
+              <div>
+                  {{revision.content|safe}}
+              </div>
+            {% else %}
+              {{ h.render_content(c.page.content) }}
+            {% endif %}
         </div>
     {% else %}
         <p class="empty">{{ _('This page currently has no content') }}</p>

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -218,7 +218,7 @@ def pages_revisions_preview(page, revision, page_type='page'):
             "revision": _page.revisions[revision]
         })
     except KeyError:
-        return tk.abort(404, _('Page Not Found'))
+        return tk.abort(404, _('Revision not found'))
 
 
 def pages_revision_restore(page, revision, page_type='page'):
@@ -231,7 +231,9 @@ def pages_revision_restore(page, revision, page_type='page'):
         tk.get_action('ckanext_pages_revision_restore')(
             context={}, data_dict={"page": page, "revision": revision}
         )
-        tk.h.flash_success(f"Content from Revision '{revision}' is being set.")
+        _page = Page.get(name=page)
+        timestamp = helpers.render_datetime(_page.revisions[revision]["created"], with_hours=True)
+        tk.h.flash_success(f"Content from revision created on {timestamp} set.")
     except TypeError:
         tk.h.flash_error(
             """Bad values, please make sure that provided values exist:

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -6,6 +6,8 @@ import ckan.plugins.toolkit as tk
 import ckan.logic as logic
 import ckan.lib.helpers as helpers
 
+from ckanext.pages.db import Page
+
 config = tk.config
 _ = tk._
 
@@ -185,6 +187,45 @@ def pages_show(page=None, page_type='page'):
     _inject_views_into_page(_page)
 
     return tk.render('ckanext_pages/%s.html' % page_type)
+
+def pages_revisions(page, page_type='page'):
+    try:
+        tk.check_access('ckanext_pages_update', {'user': tk.g.user})
+    except tk.NotAuthorized:
+        return tk.abort(401, _('Unauthorized to view this page'))
+
+    _page = Page.get(name=page)
+    tk.c.page_type = page_type
+    tk.c.page = _page
+    return tk.render('ckanext_pages/%s_revisions.html' % page_type)
+
+
+def pages_revisions_preview(page, revision, page_type='page'):
+    try:
+        tk.check_access('ckanext_pages_update', {'user': tk.g.user})
+    except tk.NotAuthorized:
+        return tk.abort(401, _('Unauthorized to view this page'))
+
+    _page = Page.get(name=page)
+    tk.c.page_type = page_type
+    tk.c.page = _page
+    return tk.render('ckanext_pages/%s_revisions_preview.html' % page_type, extra_vars={
+        "revision": _page.revisions[revision]
+    })
+
+
+def pages_revision_restore(page, revision, page_type='page'):
+    try:
+        tk.check_access('ckanext_pages_update', {'user': tk.g.user})
+    except tk.NotAuthorized:
+        return tk.abort(401, _('Unauthorized to view this page'))
+
+    tk.get_action('ckanext_pages_revision_restore')(
+        context={}, data_dict={"page": page, "revision": revision}
+    )
+
+    endpoint = 'show' if page_type in ('pages', 'page') else '%s_show' % page_type
+    return tk.redirect_to('pages.%s' % endpoint, page=page)
 
 
 def pages_delete(page, page_type='pages'):

--- a/ckanext/pages/utils.py
+++ b/ckanext/pages/utils.py
@@ -188,6 +188,7 @@ def pages_show(page=None, page_type='page'):
 
     return tk.render('ckanext_pages/%s.html' % page_type)
 
+
 def pages_revisions(page, page_type='page'):
     try:
         tk.check_access('ckanext_pages_update', {'user': tk.g.user})


### PR DESCRIPTION
Hi @amercader and  @wardi 
With this PR I want to add Revision feature to the Pages and Blog HTML content.
It is a quite straightforward feature that adds and ability to Restore previous Content state in case if something went wrong while saving current version.
By default it creates only 3 versions, while can be increased with **ckanext.pages.revisions_limit** config setting.

It shouldn't effect old pages that were created before the Revisions logic update and the first Revision for those Pages/Blogs can be create by re-saving the current version.

It required DB upgrade after pulling.

Please review, test this and let me know if any adjustments are needed.