### PR TITLE
Group activity tab compatibility for ckan 2.10.7

### DIFF
--- a/ckanext/pages/theme/templates_group/group/read_base.html
+++ b/ckanext/pages/theme/templates_group/group/read_base.html
@@ -2,8 +2,10 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% if h.ckan_version().split('.')[1] | int >= 9 %}
+  {% if h.ckan_version().split('.')[1] | int == 9 %}
     {{ h.build_nav_icon('pages.group_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
+  {% elif h.ckan_version().split('.')[1] | int >= 10 %}
+    {{ h.build_nav_icon('pages.group_pages_index', _('Pages'), id=group_dict.name, icon='file') }}
   {% else %}
     {{ h.build_nav_icon('group_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
   {% endif %}


### PR DESCRIPTION
Loading activity tab of a group in ckan 2.10.7 was sending back an internal server error because you are not supposed to access group dict from c. object

