### PR TITLE
Use CKANs Helper to create navigation urls

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -14,6 +14,7 @@ from ckanext.pages import auth
 from ckanext.pages import blueprint
 
 from ckan.lib.plugins import DefaultTranslation
+from ckan.lib.helpers import _local_url
 
 
 log = logging.getLogger(__name__)
@@ -24,7 +25,6 @@ def build_pages_nav_main(*args):
     about_menu = tk.asbool(tk.config.get('ckanext.pages.about_menu', True))
     group_menu = tk.asbool(tk.config.get('ckanext.pages.group_menu', True))
     org_menu = tk.asbool(tk.config.get('ckanext.pages.organization_menu', True))
-    root_path = tk.config.get('ckan.root_path', '/')
 
     new_args = []
     for arg in args:
@@ -51,7 +51,8 @@ def build_pages_nav_main(*args):
         type_ = 'blog' if page['page_type'] == 'blog' else 'pages'
         name = quote(page['name'])
         title = html_escape(page['title'])
-        link = tk.h.literal(u'<a href="{}/{}/{}">{}</a>'.format(root_path, type_, name, title))
+        local_url = _local_url("/{}/{}".format(type_, name))
+        link = tk.h.literal(u'<a href="{}">{}</a>'.format(local_url, title))
         if page['name'] == page_name:
             li = tk.literal('<li class="active">') + link + tk.literal('</li>')
         else:


### PR DESCRIPTION
During our last fix for including the root_path (https://github.com/ckan/ckanext-pages/pull/144), we encountered a problem when another language is used with CKAN. When a language is explicitely set in the url, the generated links by the pages plugin did not contain the language using our previous fix.

This fix uses the "internal" `_local_url` to generate the links (in my oppinion this should be a public helper function, providet by the toolkit for plugins) and thus the links will be generated with the same code CKAN uses internally. This should make the generated link robust and should always follow CKANs configuration.